### PR TITLE
Fix always firing alerts

### DIFF
--- a/assets/prometheus/rules/kubernetes.rules
+++ b/assets/prometheus/rules/kubernetes.rules
@@ -251,7 +251,7 @@ ALERT K8SApiserverDown
 
 # Disable for non HA kubernetes setups.
 ALERT K8SApiserverDown
-  IF absent({job="kubernetes"}) or count by(cluster) (up{job="kubernetes"} == 1) < 2
+  IF absent({job="kubernetes"}) or (count by(cluster) (up{job="kubernetes"} == 1) < count by(cluster) (up{job="kubernetes"})
   FOR 5m
   LABELS {
     service = "k8s",
@@ -363,7 +363,7 @@ ALERT K8STooManyOpenFiles
 ALERT K8SApiServerLatency
   IF histogram_quantile(
       0.99,
-      sum without (instance,node,resource) (apiserver_request_latencies_bucket{verb!~"CONNECT|WATCHLIST"})
+      sum without (instance,node,resource) (apiserver_request_latencies_bucket{verb!~"CONNECT|WATCHLIST|WATCH"})
     ) / 1e6 > 1.0
   FOR 10m
   LABELS {


### PR DESCRIPTION
@brancz 

All aggregations using `by(cluster)` don't apply to our default setup. They come from a scenario were multiple clusters were monitored and custom target labels were attached for each.

Left them on there for now as they don't hurt. We might be able to use them if we ever build out a cross-cluster monitoring story.