### PR TITLE
Update manifests to latest version of Prometheus Operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,10 +43,6 @@ To tear it all down again, run:
 hack/cluster-monitoring/teardown
 ```
 
-> All services in the manifest still contain the `prometheus.io/scrape = true`
-> annotations. It is not used by the Prometheus Operator. They remain for
-> pre Prometheus v1.3.0 deployments as in [this example configuration](https://github.com/prometheus/prometheus/blob/6703404cb431f57ca4c5097bc2762438d3c1968e/documentation/examples/prometheus-kubernetes.yml).
-
 ## Monitoring custom services
 
 The example manifests in [/manifests/examples/example-app](/manifests/examples/example-app)

--- a/assets/prometheus/prometheus.yaml
+++ b/assets/prometheus/prometheus.yaml
@@ -65,4 +65,4 @@ scrape_configs:
     regex: "kube-(.*)-prometheus-discovery"
   - action: keep
     source_labels: [__meta_kubernetes_endpoint_port_name]
-    regex: "prometheus"
+    regex: "prometheus.*"

--- a/manifests/alertmanager/alertmanager-config.yaml
+++ b/manifests/alertmanager/alertmanager-config.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: alertmanager-main
+data:
+  alertmanager.yaml: |-
+    global:
+      resolve_timeout: 5m
+    route:
+      group_by: ['job']
+      group_wait: 30s
+      group_interval: 5m
+      repeat_interval: 12h
+      receiver: 'webhook'
+    receivers:
+    - name: 'webhook'
+      webhook_configs:
+      - url: 'http://alertmanagerwh:30500/'

--- a/manifests/alertmanager/alertmanager-service.yaml
+++ b/manifests/alertmanager/alertmanager-service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: alertmanager-main
+spec:
+  type: NodePort
+  ports:
+  - name: web
+    nodePort: 30903
+    port: 9093
+    protocol: TCP
+    targetPort: web
+  selector:
+    alertmanager: alertmanager-main

--- a/manifests/alertmanager/alertmanager.yaml
+++ b/manifests/alertmanager/alertmanager.yaml
@@ -1,0 +1,9 @@
+apiVersion: "monitoring.coreos.com/v1alpha1"
+kind: "Alertmanager"
+metadata:
+  name: "alertmanager-main"
+  labels:
+    alertmanager: "main"
+spec:
+  replicas: 3
+  version: v0.5.1

--- a/manifests/etcd/etcd-bootkube-gce.yaml
+++ b/manifests/etcd/etcd-bootkube-gce.yaml
@@ -5,8 +5,6 @@ metadata:
   labels:
     app: etcd
     etcd: k8s
-  annotations:
-    prometheus.io/scrape: 'true'
 spec:
   type: ClusterIP
   clusterIP: None

--- a/manifests/etcd/etcd-bootkube-vagrant-multi.yaml
+++ b/manifests/etcd/etcd-bootkube-vagrant-multi.yaml
@@ -5,8 +5,6 @@ metadata:
   labels:
     app: etcd
     etcd: k8s
-  annotations:
-    prometheus.io/scrape: 'true'
 spec:
   type: ClusterIP
   clusterIP: None

--- a/manifests/examples/example-app/example-app.yaml
+++ b/manifests/examples/example-app/example-app.yaml
@@ -4,8 +4,6 @@ metadata:
   name: example-app
   labels:
     tier: frontend
-  annotations:
-    prometheus.io/scrape: 'true'
 spec: 
   selector: 
     app: example-app 

--- a/manifests/examples/example-app/prometheus-frontend.yaml
+++ b/manifests/examples/example-app/prometheus-frontend.yaml
@@ -11,3 +11,10 @@ spec:
   - selector:
       matchLabels:
         tier: frontend
+  resources:
+    requests:
+      # 2Gi is default, but won't schedule if you don't have a node with >2Gi
+      # memory. Modify based on your target and time-series count for
+      # production use. This value is mainly meant for demonstration/testing
+      # purposes.
+      memory: 400Mi

--- a/manifests/examples/example-app/prometheus-frontend.yaml
+++ b/manifests/examples/example-app/prometheus-frontend.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     prometheus: frontend
 spec:
-  version: v1.3.0
+  version: v1.4.1
   serviceMonitors:
   - selector:
       matchLabels:
@@ -18,3 +18,8 @@ spec:
       # production use. This value is mainly meant for demonstration/testing
       # purposes.
       memory: 400Mi
+  alerting:
+    alertmanagers:
+    - namespace: monitoring
+      name: alertmanager-main
+      port: web

--- a/manifests/exporters/kube-state-metrics-svc.yaml
+++ b/manifests/exporters/kube-state-metrics-svc.yaml
@@ -1,8 +1,6 @@
 apiVersion: v1
 kind: Service
 metadata:
-  annotations:
-    prometheus.io/scrape: 'true'
   labels:
     app: kube-state-metrics
   name: kube-state-metrics

--- a/manifests/exporters/node-exporter-ds.yaml
+++ b/manifests/exporters/node-exporter-ds.yaml
@@ -12,7 +12,7 @@ spec:
       hostNetwork: true
       hostPID: true
       containers:
-      - image:  quay.io/prometheus/node-exporter:0.12.0
+      - image:  quay.io/prometheus/node-exporter:0.13.0
         args:
         - "-collector.procfs=/host/proc"
         - "-collector.sysfs=/host/sys"

--- a/manifests/exporters/node-exporter-svc.yaml
+++ b/manifests/exporters/node-exporter-svc.yaml
@@ -3,8 +3,6 @@ kind: Service
 metadata:
   labels:
     app: node-exporter
-  annotations:
-    prometheus.io/scrape: 'true'
   name: node-exporter
 spec:
   type: ClusterIP

--- a/manifests/grafana/grafana-svc.yaml
+++ b/manifests/grafana/grafana-svc.yaml
@@ -4,8 +4,6 @@ metadata:
   name: grafana
   labels:
     app: grafana
-  annotations:
-    prometheus.io/scrape: 'true'
 spec:
   type: NodePort
   ports:

--- a/manifests/k8s/kube-controller-manager-bootkube-vagrant-multi.yaml
+++ b/manifests/k8s/kube-controller-manager-bootkube-vagrant-multi.yaml
@@ -4,8 +4,6 @@ metadata:
   name: kube-controller-manager-prometheus-discovery
   labels:
     k8s-app: kube-controller-manager
-  annotations:
-    prometheus.io/scrape: 'true'
 spec:
   selector:
     k8s-app: kube-controller-manager

--- a/manifests/k8s/kube-dns-bootkube-vagrant-multi.yaml
+++ b/manifests/k8s/kube-dns-bootkube-vagrant-multi.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: kube-dns-prometheus-discovery
+  labels:
+    k8s-app: kube-dns
+spec:
+  selector:
+    k8s-app: kube-dns
+  type: ClusterIP
+  clusterIP: None
+  ports:
+  - name: prometheus-skydns
+    port: 10055
+    targetPort: 10055
+    protocol: TCP
+  - name: prometheus-dnsmasq
+    port: 10054
+    targetPort: 10054
+    protocol: TCP

--- a/manifests/k8s/kube-scheduler-bootkube-vagrant-multi.yaml
+++ b/manifests/k8s/kube-scheduler-bootkube-vagrant-multi.yaml
@@ -4,8 +4,6 @@ metadata:
   name: kube-scheduler-prometheus-discovery
   labels:
     k8s-app: kube-scheduler
-  annotations:
-    prometheus.io/scrape: 'true'
 spec:
   selector:
     k8s-app: kube-scheduler

--- a/manifests/prometheus/prometheus-k8s-cm.yaml
+++ b/manifests/prometheus/prometheus-k8s-cm.yaml
@@ -68,7 +68,7 @@ data:
         regex: "kube-(.*)-prometheus-discovery"
       - action: keep
         source_labels: [__meta_kubernetes_endpoint_port_name]
-        regex: "prometheus"
+        regex: "prometheus.*"
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/manifests/prometheus/prometheus-k8s.yaml
+++ b/manifests/prometheus/prometheus-k8s.yaml
@@ -6,3 +6,10 @@ metadata:
     prometheus: k8s
 spec:
   version: v1.3.0
+  resources:
+    requests:
+      # 2Gi is default, but won't schedule if you don't have a node with >2Gi
+      # memory. Modify based on your target and time-series count for
+      # production use. This value is mainly meant for demonstration/testing
+      # purposes.
+      memory: 400Mi

--- a/manifests/prometheus/prometheus-k8s.yaml
+++ b/manifests/prometheus/prometheus-k8s.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     prometheus: k8s
 spec:
-  version: v1.3.0
+  version: v1.4.1
   resources:
     requests:
       # 2Gi is default, but won't schedule if you don't have a node with >2Gi
@@ -13,3 +13,8 @@ spec:
       # production use. This value is mainly meant for demonstration/testing
       # purposes.
       memory: 400Mi
+  alerting:
+    alertmanagers:
+    - namespace: monitoring
+      name: alertmanager-main
+      port: web


### PR DESCRIPTION
Tried out with a container image of `HEAD` of the Prometheus Operator.

List of changes divided into commits:
* Set lower resource requests by default (simply for demo purposes, as this currently won't work on minikube for example with only 1Gb of memory)
* Remove unnecessary prometheus.io/scrape annotation: (tl;dr) more confusing then helpful
* Add Alertmanager support in TPRs and manifests themselves (recently added to Prometheus Operator)
* Add kube-dns service for skydns and dnsmasq metrics to be collected. This change reflects work [upstream](https://github.com/kubernetes/kubernetes/blob/545f749a0deb8535656ce93ac1f35a59887839bf/cluster/addons/dns/skydns-rc.yaml.sed) and on [bootkube](https://github.com/kubernetes-incubator/bootkube/pull/179).
* Update `node-exporter` version

It would probably make sense to cut another release of the Prometheus Operator, just so we can at least partially version this until we get versioned user-guides.

@fabxc 
