### PR TITLE
Fixed docker image tag for "quay.io/prometheus/node-exporter". 

### DIFF
--- a/manifests/exporters/node-exporter-ds.yaml
+++ b/manifests/exporters/node-exporter-ds.yaml
@@ -12,7 +12,7 @@ spec:
       hostNetwork: true
       hostPID: true
       containers:
-      - image:  quay.io/prometheus/node-exporter:0.13.0
+      - image:  quay.io/prometheus/node-exporter:v0.13.0
         args:
         - "-collector.procfs=/host/proc"
         - "-collector.sysfs=/host/sys"


### PR DESCRIPTION
The docker image tag for the node exporter ("quay.io/prometheus/node-exporter") was not valid so I changed it to "v0.13.0".