### PR TITLE
*: cleanup and unify minikube and self-hosted discovery

### DIFF
--- a/assets/prometheus/prometheus.yaml
+++ b/assets/prometheus/prometheus.yaml
@@ -53,15 +53,10 @@ scrape_configs:
   relabel_configs:
   - action: keep
     source_labels: [__meta_kubernetes_service_name]
-    regex: prometheus|kubernetes|node-exporter|kube-state-metrics|etcd-k8s
+    regex: prometheus|node-exporter|kube-state-metrics
   - action: replace
     source_labels: [__meta_kubernetes_service_name]
     target_label: job
-  - action: replace
-    source_labels: [__meta_kubernetes_service_name]
-    regex: kubernetes
-    target_label: __scheme__
-    replacement: https
 
 # Scrapes the endpoint lists for the kube-dns server. Which we consider
 # part of a default setup.
@@ -75,13 +70,16 @@ scrape_configs:
 
   relabel_configs:
   - action: replace
-    source_labels: [__meta_kubernetes_service_name]
+    source_labels: [__meta_kubernetes_service_label_k8s_app]
     target_label: job
-    regex: "kube-(.*)-prometheus-discovery"
-    replacement: "kube-${1}"
   - action: keep
     source_labels: [__meta_kubernetes_service_name]
-    regex: "kube-(.*)-prometheus-discovery"
+    regex: ".*-prometheus-discovery"
   - action: keep
     source_labels: [__meta_kubernetes_endpoint_port_name]
-    regex: "prometheus.*"
+    regex: "http-metrics.*|https-metrics.*"
+  - action: replace
+    source_labels: [__meta_kubernetes_endpoint_port_name]
+    regex: "https-metrics.*"
+    target_label: __scheme__
+    replacement: https

--- a/hack/cluster-monitoring/deploy
+++ b/hack/cluster-monitoring/deploy
@@ -4,19 +4,24 @@ if [ -z "${KUBECONFIG}" ]; then
     KUBECONFIG=~/.kube/config
 fi
 
-kubectl --kubeconfig="$KUBECONFIG" create namespace monitoring
+if [ -z "${NAMESPACE}" ]; then
+    NAMESPACE=monitoring
+fi
+
+kubectl --kubeconfig="$KUBECONFIG" create namespace "$NAMESPACE"
 
 kctl() {
-    kubectl --kubeconfig="$KUBECONFIG" -n "monitoring" "$@"
+    kubectl --kubeconfig="$KUBECONFIG" -n "$NAMESPACE" "$@"
 }
 
-kctl apply -f manifests/prometheus-operator.yaml
+kctl create -f manifests/prometheus-operator.yaml
 
 # Wait for TPRs to be ready.
 until kctl get servicemonitor; do sleep 1; done
 until kctl get prometheus; do sleep 1; done
+until kctl get alertmanager; do sleep 1; done
 
-kctl apply -f manifests/exporters
-kctl apply -f manifests/grafana
-kctl apply -f manifests/prometheus
-kctl apply -f manifests/alertmanager
+kctl create -f manifests/exporters
+kctl create -f manifests/grafana
+kctl create -f manifests/prometheus
+kctl create -f manifests/alertmanager

--- a/hack/cluster-monitoring/teardown
+++ b/hack/cluster-monitoring/teardown
@@ -4,8 +4,12 @@ if [ -z "${KUBECONFIG}" ]; then
     KUBECONFIG=~/.kube/config
 fi
 
+if [ -z "${NAMESPACE}" ]; then
+    NAMESPACE=monitoring
+fi
+
 kctl() {
-    kubectl --kubeconfig="$KUBECONFIG" -n "monitoring" "$@"
+    kubectl --kubeconfig="$KUBECONFIG" -n "$NAMESPACE" "$@"
 }
 
 kctl delete -f manifests/exporters

--- a/manifests/etcd/etcd-bootkube-gce.yaml
+++ b/manifests/etcd/etcd-bootkube-gce.yaml
@@ -3,8 +3,7 @@ kind: Service
 metadata:
   name: etcd-k8s
   labels:
-    app: etcd
-    etcd: k8s
+    k8s-app: etcd
 spec:
   type: ClusterIP
   clusterIP: None
@@ -18,8 +17,7 @@ kind: Endpoints
 metadata:
   name: etcd-k8s
   labels:
-    app: etcd
-    etcd: k8s
+    k8s-app: etcd
 subsets:
 - addresses:
   - ip: 10.142.0.2

--- a/manifests/etcd/etcd-bootkube-vagrant-multi.yaml
+++ b/manifests/etcd/etcd-bootkube-vagrant-multi.yaml
@@ -3,8 +3,7 @@ kind: Service
 metadata:
   name: etcd-k8s
   labels:
-    app: etcd
-    etcd: k8s
+    k8s-app: etcd
 spec:
   type: ClusterIP
   clusterIP: None
@@ -18,8 +17,7 @@ kind: Endpoints
 metadata:
   name: etcd-k8s
   labels:
-    app: etcd
-    etcd: k8s
+    k8s-app: etcd
 subsets:
 - addresses:
   - ip: 172.17.4.51

--- a/manifests/k8s/minikube/kube-apiserver.yaml
+++ b/manifests/k8s/minikube/kube-apiserver.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: kube-apiserver-prometheus-discovery
+  labels:
+    k8s-app: kubernetes
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+  - name: https-metrics
+    port: 8443
+    protocol: TCP
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  name: kube-apiserver-prometheus-discovery
+  labels:
+    k8s-app: kubernetes
+subsets:
+- addresses:
+  - ip: 192.168.99.100
+  ports:
+  - name: https-metrics
+    port: 8443
+    protocol: TCP

--- a/manifests/k8s/minikube/kube-controller-manager.yaml
+++ b/manifests/k8s/minikube/kube-controller-manager.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: kube-controller-manager-prometheus-discovery
+  labels:
+    k8s-app: kube-controller-manager
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+  - name: http-metrics
+    port: 10252
+    targetPort: 10252
+    protocol: TCP
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  name: kube-controller-manager-prometheus-discovery
+  labels:
+    k8s-app: kube-controller-manager
+subsets:
+- addresses:
+  - ip: 192.168.99.100
+  ports:
+  - name: http-metrics
+    port: 10252
+    protocol: TCP

--- a/manifests/k8s/minikube/kube-scheduler.yaml
+++ b/manifests/k8s/minikube/kube-scheduler.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: kube-scheduler-prometheus-discovery
+  labels:
+    k8s-app: kube-scheduler
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+  - name: http-metrics
+    port: 10251
+    targetPort: 10251
+    protocol: TCP
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  name: kube-scheduler-prometheus-discovery
+  labels:
+    k8s-app: kube-scheduler
+subsets:
+- addresses:
+  - ip: 192.168.99.100
+  ports:
+  - name: http-metrics
+    port: 10251
+    protocol: TCP

--- a/manifests/k8s/self-hosted/kube-apiserver.yaml
+++ b/manifests/k8s/self-hosted/kube-apiserver.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: kube-apiserver-prometheus-discovery
+  labels:
+    k8s-app: kubernetes
+spec:
+  selector:
+    k8s-app: kube-apiserver
+  type: ClusterIP
+  clusterIP: None
+  ports:
+  - name: https-metrics
+    port: 443
+    targetPort: 443
+    protocol: TCP

--- a/manifests/k8s/self-hosted/kube-controller-manager.yaml
+++ b/manifests/k8s/self-hosted/kube-controller-manager.yaml
@@ -10,7 +10,7 @@ spec:
   type: ClusterIP
   clusterIP: None
   ports:
-  - name: prometheus
+  - name: http-metrics
     port: 10252
     targetPort: 10252
     protocol: TCP

--- a/manifests/k8s/self-hosted/kube-dns.yaml
+++ b/manifests/k8s/self-hosted/kube-dns.yaml
@@ -10,11 +10,11 @@ spec:
   type: ClusterIP
   clusterIP: None
   ports:
-  - name: prometheus-skydns
+  - name: http-metrics-skydns
     port: 10055
     targetPort: 10055
     protocol: TCP
-  - name: prometheus-dnsmasq
+  - name: http-metrics-dnsmasq
     port: 10054
     targetPort: 10054
     protocol: TCP

--- a/manifests/k8s/self-hosted/kube-scheduler.yaml
+++ b/manifests/k8s/self-hosted/kube-scheduler.yaml
@@ -10,7 +10,7 @@ spec:
   type: ClusterIP
   clusterIP: None
   ports:
-  - name: prometheus
+  - name: http-metrics
     port: 10251
     targetPort: 10251
     protocol: TCP

--- a/manifests/prometheus-operator.yaml
+++ b/manifests/prometheus-operator.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
        - name: prometheus-operator
-         image: quay.io/coreos/prometheus-operator:v0.1.0
+         image: quay.io/coreos/prometheus-operator:v0.2.1
          resources:
            requests:
              cpu: 100m

--- a/manifests/prometheus/prometheus-k8s-cm.yaml
+++ b/manifests/prometheus/prometheus-k8s-cm.yaml
@@ -56,15 +56,10 @@ data:
       relabel_configs:
       - action: keep
         source_labels: [__meta_kubernetes_service_name]
-        regex: prometheus|kubernetes|node-exporter|kube-state-metrics|etcd-k8s
+        regex: prometheus|node-exporter|kube-state-metrics
       - action: replace
         source_labels: [__meta_kubernetes_service_name]
         target_label: job
-      - action: replace
-        source_labels: [__meta_kubernetes_service_name]
-        regex: kubernetes
-        target_label: __scheme__
-        replacement: https
 
     # Scrapes the endpoint lists for the kube-dns server. Which we consider
     # part of a default setup.
@@ -78,16 +73,19 @@ data:
 
       relabel_configs:
       - action: replace
-        source_labels: [__meta_kubernetes_service_name]
+        source_labels: [__meta_kubernetes_service_label_k8s_app]
         target_label: job
-        regex: "kube-(.*)-prometheus-discovery"
-        replacement: "kube-${1}"
       - action: keep
         source_labels: [__meta_kubernetes_service_name]
-        regex: "kube-(.*)-prometheus-discovery"
+        regex: ".*-prometheus-discovery"
       - action: keep
         source_labels: [__meta_kubernetes_endpoint_port_name]
-        regex: "prometheus.*"
+        regex: "http-metrics.*|https-metrics.*"
+      - action: replace
+        source_labels: [__meta_kubernetes_endpoint_port_name]
+        regex: "https-metrics.*"
+        target_label: __scheme__
+        replacement: https
 kind: ConfigMap
 metadata:
   creationTimestamp: null


### PR DESCRIPTION
This puts us very close to generating the config with `ServiceMonitor`s. Besides a lot of unification and cleanup this upgrades to `v0.2.1` of the prometheus operator so from now on `v1.5.x` clusters are required for the `hack/` scripts. Not that the content of this repo is now specific to `v1.5.x` it is just targeted by the operator, for `v1.4.x` clusters simply use the `v0.1.1` of the operator all other content should work the same way, but untested.

@fabxc @alexsomesan

Happy Holidays 🎉 🎅 🎄 🎁 