### PR TITLE
Don't pass $KUBECONFIG to kubectl --kubeconfig flag

### DIFF
--- a/hack/cluster-monitoring/deploy
+++ b/hack/cluster-monitoring/deploy
@@ -1,17 +1,17 @@
 #!/usr/bin/env bash
 
 if [ -z "${KUBECONFIG}" ]; then
-    KUBECONFIG=~/.kube/config
+    export KUBECONFIG=~/.kube/config
 fi
 
 if [ -z "${NAMESPACE}" ]; then
     NAMESPACE=monitoring
 fi
 
-kubectl --kubeconfig="$KUBECONFIG" create namespace "$NAMESPACE"
+kubectl create namespace "$NAMESPACE"
 
 kctl() {
-    kubectl --kubeconfig="$KUBECONFIG" -n "$NAMESPACE" "$@"
+    kubectl --namespace "$NAMESPACE" "$@"
 }
 
 kctl create -f manifests/prometheus-operator.yaml

--- a/hack/cluster-monitoring/teardown
+++ b/hack/cluster-monitoring/teardown
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 if [ -z "${KUBECONFIG}" ]; then
-    KUBECONFIG=~/.kube/config
+    export KUBECONFIG=~/.kube/config
 fi
 
 if [ -z "${NAMESPACE}" ]; then
@@ -9,7 +9,7 @@ if [ -z "${NAMESPACE}" ]; then
 fi
 
 kctl() {
-    kubectl --kubeconfig="$KUBECONFIG" -n "$NAMESPACE" "$@"
+    kubectl --namespace "$NAMESPACE" "$@"
 }
 
 kctl delete -f manifests/exporters


### PR DESCRIPTION
The $KUBECONFIG variable is like $PATH, and supports multiple files
separated by `:`, but --kubeconfig only takes a single file as a value.
Since kubectl picks up the $KUBECONFIG variable already, don't pass it
to kubectl.

Also, use --namespace instead of -n to support older kubectl versions.