### PR TITLE
hack/*: use kubectl apply where possible

### DIFF
--- a/hack/cluster-monitoring/deploy
+++ b/hack/cluster-monitoring/deploy
@@ -14,14 +14,26 @@ kctl() {
     kubectl --namespace "$NAMESPACE" "$@"
 }
 
-kctl create -f manifests/prometheus-operator.yaml
+kctl apply -f manifests/prometheus-operator.yaml
 
 # Wait for TPRs to be ready.
 until kctl get servicemonitor; do sleep 1; done
 until kctl get prometheus; do sleep 1; done
 until kctl get alertmanager; do sleep 1; done
 
-kctl create -f manifests/exporters
-kctl create -f manifests/grafana
-kctl create -f manifests/prometheus
-kctl create -f manifests/alertmanager
+kctl apply -f manifests/exporters
+kctl apply -f manifests/grafana
+
+kctl apply -f manifests/prometheus/prometheus-k8s-cm.yaml
+kctl apply -f manifests/prometheus/prometheus-k8s-rules.yaml
+kctl apply -f manifests/prometheus/prometheus-k8s-svc.yaml
+
+kctl apply -f manifests/alertmanager/alertmanager-config.yaml
+kctl apply -f manifests/alertmanager/alertmanager-service.yaml
+
+# `kubectl apply` is currently not working for third party resources so we are
+# using `kubectl create` here for the time being.
+# (https://github.com/kubernetes/kubernetes/issues/29542)
+kctl create -f manifests/prometheus/prometheus-k8s.yaml
+kctl create -f manifests/alertmanager/alertmanager.yaml
+

--- a/hack/cluster-monitoring/teardown
+++ b/hack/cluster-monitoring/teardown
@@ -21,3 +21,4 @@ kctl delete -f manifests/alertmanager
 sleep 5
 
 kctl delete -f manifests/prometheus-operator.yaml
+

--- a/hack/example-service-monitoring/deploy
+++ b/hack/example-service-monitoring/deploy
@@ -4,4 +4,8 @@ if [ -z "${KUBECONFIG}" ]; then
     KUBECONFIG=~/.kube/config
 fi
 
-kubectl --kubeconfig="$KUBECONFIG" create -f manifests/examples/example-app
+kubectl --kubeconfig="$KUBECONFIG" apply -f manifests/examples/example-app/prometheus-frontend-svc.yaml
+kubectl --kubeconfig="$KUBECONFIG" apply -f manifests/examples/example-app/example-app.yaml
+kubectl --kubeconfig="$KUBECONFIG" create -f manifests/examples/example-app/prometheus-frontend.yaml
+kubectl --kubeconfig="$KUBECONFIG" create -f manifests/examples/example-app/servicemonitor-frontend.yaml
+

--- a/hack/example-service-monitoring/teardown
+++ b/hack/example-service-monitoring/teardown
@@ -5,3 +5,4 @@ if [ -z "${KUBECONFIG}" ]; then
 fi
 
 kubectl --kubeconfig="$KUBECONFIG" delete -f manifests/examples/example-app
+

--- a/hack/scripts/generate-configmaps.sh
+++ b/hack/scripts/generate-configmaps.sh
@@ -8,3 +8,4 @@ kubectl create configmap --dry-run=true prometheus-k8s-rules --from-file=assets/
 
 # Generate Dashboard ConfigMap
 kubectl create configmap --dry-run=true grafana-dashboards --from-file=assets/grafana/ -oyaml > manifests/grafana/grafana-cm.yaml
+


### PR DESCRIPTION
There is an issue with kubectl apply and third party resources, so for
the time being we use create for TPRs, but apply for all manifests that
it can handle.

Based on discussion in #24.

@chancez @genti-t @fabxc @alexsomesan
