### PR TITLE
hack/cluster-monitoring: hide expected errors and print meaning

### DIFF
--- a/hack/cluster-monitoring/deploy
+++ b/hack/cluster-monitoring/deploy
@@ -17,9 +17,11 @@ kctl() {
 kctl apply -f manifests/prometheus-operator.yaml
 
 # Wait for TPRs to be ready.
-until kctl get servicemonitor; do sleep 1; done
-until kctl get prometheus; do sleep 1; done
-until kctl get alertmanager; do sleep 1; done
+printf "Waiting for Operator to register third party objects..."
+until kctl get servicemonitor > /dev/null 2>&1; do sleep 1; printf "."; done
+until kctl get prometheus > /dev/null 2>&1; do sleep 1; printf "."; done
+until kctl get alertmanager > /dev/null 2>&1; do sleep 1; printf "."; done
+echo "done!"
 
 kctl apply -f manifests/exporters
 kctl apply -f manifests/grafana


### PR DESCRIPTION
When trying out `kube-prometheus` and running the `hack/` scripts and see errors, it feels like the user is doing something incorrectly, while those are expected errors when deploying the operator for the first time.

@fabxc @alexsomesan