### PR TITLE
fix memory/disk gauges and use rate

### DIFF
--- a/assets/grafana/node-dashboard.json
+++ b/assets/grafana/node-dashboard.json
@@ -100,7 +100,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "100 - (avg by (cpu) (irate(node_cpu{mode=\"idle\", instance=~\"$server\"}[5m])) * 100)",
+              "expr": "100 - (avg by (cpu) (irate(node_cpu{mode=\"idle\", instance=\"$server\"}[5m])) * 100)",
               "hide": false,
               "intervalFactor": 10,
               "legendFormat": "{{cpu}}",
@@ -188,7 +188,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "node_load1{instance=~\"$server\"}",
+              "expr": "node_load1{instance=\"$server\"}",
               "intervalFactor": 4,
               "legendFormat": "load 1m",
               "refId": "A",
@@ -196,7 +196,7 @@
               "target": ""
             },
             {
-              "expr": "node_load5{instance=~\"$server\"}",
+              "expr": "node_load5{instance=\"$server\"}",
               "intervalFactor": 4,
               "legendFormat": "load 5m",
               "refId": "B",
@@ -204,7 +204,7 @@
               "target": ""
             },
             {
-              "expr": "node_load15{instance=~\"$server\"}",
+              "expr": "node_load15{instance=\"$server\"}",
               "intervalFactor": 4,
               "legendFormat": "load 15m",
               "refId": "C",
@@ -305,7 +305,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "node_memory_MemTotal{instance=~\"$server\"} - node_memory_MemFree{instance=~\"$server\"}",
+              "expr": "node_memory_MemTotal{instance=\"$server\"} - node_memory_MemFree{instance=\"$server\"}",
               "intervalFactor": 2,
               "legendFormat": "memory usage",
               "metric": "memo",
@@ -314,7 +314,7 @@
               "target": ""
             },
             {
-              "expr": "node_memory_MemTotal{instance=~\"$server\"}",
+              "expr": "node_memory_MemTotal{instance=\"$server\"}",
               "intervalFactor": 2,
               "legendFormat": "memory total",
               "metric": "memo",
@@ -414,7 +414,7 @@
           },
           "targets": [
             {
-              "expr": "((node_memory_MemTotal{instance=~\"$server\"} - node_memory_MemFree{instance=~\"$server\"}) / node_memory_MemTotal{instance=~\"$server\"}) * 100",
+              "expr": "((node_memory_MemTotal{instance=\"$server\"} - node_memory_MemFree{instance=\"$server\"}) / node_memory_MemTotal{instance=\"$server\"}) * 100",
               "intervalFactor": 2,
               "refId": "A",
               "step": 60,
@@ -502,7 +502,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum by (instance) (rate(node_disk_bytes_read{instance=~\"$server\"}[2m]))",
+              "expr": "sum by (instance) (rate(node_disk_bytes_read{instance=\"$server\"}[2m]))",
               "hide": false,
               "intervalFactor": 4,
               "legendFormat": "read",
@@ -511,14 +511,14 @@
               "target": ""
             },
             {
-              "expr": "sum by (instance) (rate(node_disk_bytes_written{instance=~\"$server\"}[2m]))",
+              "expr": "sum by (instance) (rate(node_disk_bytes_written{instance=\"$server\"}[2m]))",
               "intervalFactor": 4,
               "legendFormat": "written",
               "refId": "B",
               "step": 8
             },
             {
-              "expr": "sum by (instance) (rate(node_disk_io_time_ms{instance=~\"$server\"}[2m]))",
+              "expr": "sum by (instance) (rate(node_disk_io_time_ms{instance=\"$server\"}[2m]))",
               "intervalFactor": 4,
               "legendFormat": "io time",
               "refId": "C",
@@ -616,7 +616,7 @@
           },
           "targets": [
             {
-              "expr": "(sum(node_filesystem_size{device!=\"rootfs\",instance=~\"$server\"}) - sum(node_filesystem_free{device!=\"rootfs\",instance=~\"$server\"})) / sum(node_filesystem_size{device!=\"rootfs\",instance=~\"$server\"})",
+              "expr": "(sum(node_filesystem_size{device!=\"rootfs\",instance=\"$server\"}) - sum(node_filesystem_free{device!=\"rootfs\",instance=\"$server\"})) / sum(node_filesystem_size{device!=\"rootfs\",instance=\"$server\"})",
               "intervalFactor": 2,
               "refId": "A",
               "step": 60,
@@ -696,7 +696,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(node_network_receive_bytes{instance=~\"$server\",device!~\"lo\"}[5m])",
+              "expr": "rate(node_network_receive_bytes{instance=\"$server\",device!~\"lo\"}[5m])",
               "hide": false,
               "intervalFactor": 2,
               "legendFormat": "{{device}}",
@@ -790,7 +790,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(node_network_transmit_bytes{instance=~\"$server\",device!~\"lo\"}[5m])",
+              "expr": "rate(node_network_transmit_bytes{instance=\"$server\",device!~\"lo\"}[5m])",
               "hide": false,
               "intervalFactor": 2,
               "legendFormat": "{{device}}",

--- a/assets/grafana/node-dashboard.json
+++ b/assets/grafana/node-dashboard.json
@@ -307,9 +307,18 @@
             {
               "expr": "node_memory_MemTotal{instance=~\"$server\"} - node_memory_MemFree{instance=~\"$server\"}",
               "intervalFactor": 2,
-              "legendFormat": "free memory",
+              "legendFormat": "memory usage",
               "metric": "memo",
               "refId": "A",
+              "step": 4,
+              "target": ""
+            },
+            {
+              "expr": "node_memory_MemTotal{instance=~\"$server\"}",
+              "intervalFactor": 2,
+              "legendFormat": "memory total",
+              "metric": "memo",
+              "refId": "B",
               "step": 4,
               "target": ""
             }
@@ -317,7 +326,7 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Free memory",
+          "title": "Memory usage",
           "tooltip": {
             "msResolution": false,
             "shared": true,
@@ -352,9 +361,9 @@
           "colorBackground": false,
           "colorValue": false,
           "colors": [
-            "rgba(245, 54, 54, 0.9)",
+            "rgba(50, 172, 45, 0.97)",
             "rgba(237, 129, 40, 0.89)",
-            "rgba(50, 172, 45, 0.97)"
+            "rgba(245, 54, 54, 0.9)"
           ],
           "datasource": "${DS_PROMETHEUS}",
           "editable": true,
@@ -405,15 +414,15 @@
           },
           "targets": [
             {
-              "expr": "(node_memory_MemFree{instance=~\"$server\"} / node_memory_MemTotal{instance=~\"$server\"}) * 100",
+              "expr": "((node_memory_MemTotal{instance=~\"$server\"} - node_memory_MemFree{instance=~\"$server\"}) / node_memory_MemTotal{instance=~\"$server\"}) * 100",
               "intervalFactor": 2,
               "refId": "A",
               "step": 60,
               "target": ""
             }
           ],
-          "thresholds": "10, 20",
-          "title": "Free memory",
+          "thresholds": "80, 90",
+          "title": "Memory usage",
           "type": "singlestat",
           "valueFontSize": "80%",
           "valueMaps": [
@@ -519,7 +528,7 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Disk usage",
+          "title": "Disk I/O",
           "tooltip": {
             "msResolution": false,
             "shared": true,
@@ -554,9 +563,9 @@
           "colorBackground": false,
           "colorValue": false,
           "colors": [
-            "rgba(245, 54, 54, 0.9)",
+            "rgba(50, 172, 45, 0.97)",
             "rgba(237, 129, 40, 0.89)",
-            "rgba(50, 172, 45, 0.97)"
+            "rgba(245, 54, 54, 0.9)"
           ],
           "datasource": "${DS_PROMETHEUS}",
           "editable": true,
@@ -607,15 +616,15 @@
           },
           "targets": [
             {
-              "expr": "sum(node_filesystem_free{device!=\"rootfs\",instance=~\"$server\"}) / sum(node_filesystem_size{device!=\"rootfs\",instance=~\"$server\"})",
+              "expr": "(sum(node_filesystem_size{device!=\"rootfs\",instance=~\"$server\"}) - sum(node_filesystem_free{device!=\"rootfs\",instance=~\"$server\"})) / sum(node_filesystem_size{device!=\"rootfs\",instance=~\"$server\"})",
               "intervalFactor": 2,
               "refId": "A",
               "step": 60,
               "target": ""
             }
           ],
-          "thresholds": "0.10, 0.25",
-          "title": "Free disk space",
+          "thresholds": "0.75, 0.9",
+          "title": "Disk space usage",
           "type": "singlestat",
           "valueFontSize": "80%",
           "valueMaps": [

--- a/assets/grafana/node-dashboard.json
+++ b/assets/grafana/node-dashboard.json
@@ -502,7 +502,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum by (instance) (irate(node_disk_bytes_read{instance=~\"$server\"}[5m]))",
+              "expr": "sum by (instance) (rate(node_disk_bytes_read{instance=~\"$server\"}[2m]))",
               "hide": false,
               "intervalFactor": 4,
               "legendFormat": "read",
@@ -511,14 +511,14 @@
               "target": ""
             },
             {
-              "expr": "sum by (instance) (irate(node_disk_bytes_written{instance=~\"$server\"}[5m]))",
+              "expr": "sum by (instance) (rate(node_disk_bytes_written{instance=~\"$server\"}[2m]))",
               "intervalFactor": 4,
               "legendFormat": "written",
               "refId": "B",
               "step": 8
             },
             {
-              "expr": "sum by (instance) (irate(node_disk_io_time_ms{instance=~\"$server\"}[5m]))",
+              "expr": "sum by (instance) (rate(node_disk_io_time_ms{instance=~\"$server\"}[2m]))",
               "intervalFactor": 4,
               "legendFormat": "io time",
               "refId": "C",
@@ -696,7 +696,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "irate(node_network_receive_bytes{instance=~\"$server\",device!~\"lo\"}[5m])",
+              "expr": "rate(node_network_receive_bytes{instance=~\"$server\",device!~\"lo\"}[5m])",
               "hide": false,
               "intervalFactor": 2,
               "legendFormat": "{{device}}",
@@ -790,7 +790,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "irate(node_network_transmit_bytes{instance=~\"$server\",device!~\"lo\"}[5m])",
+              "expr": "rate(node_network_transmit_bytes{instance=~\"$server\",device!~\"lo\"}[5m])",
               "hide": false,
               "intervalFactor": 2,
               "legendFormat": "{{device}}",

--- a/manifests/grafana/grafana-cm.yaml
+++ b/manifests/grafana/grafana-cm.yaml
@@ -2614,7 +2614,7 @@ data:
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "sum by (instance) (irate(node_disk_bytes_read{instance=~\"$server\"}[5m]))",
+                  "expr": "sum by (instance) (rate(node_disk_bytes_read{instance=~\"$server\"}[2m]))",
                   "hide": false,
                   "intervalFactor": 4,
                   "legendFormat": "read",
@@ -2623,14 +2623,14 @@ data:
                   "target": ""
                 },
                 {
-                  "expr": "sum by (instance) (irate(node_disk_bytes_written{instance=~\"$server\"}[5m]))",
+                  "expr": "sum by (instance) (rate(node_disk_bytes_written{instance=~\"$server\"}[2m]))",
                   "intervalFactor": 4,
                   "legendFormat": "written",
                   "refId": "B",
                   "step": 8
                 },
                 {
-                  "expr": "sum by (instance) (irate(node_disk_io_time_ms{instance=~\"$server\"}[5m]))",
+                  "expr": "sum by (instance) (rate(node_disk_io_time_ms{instance=~\"$server\"}[2m]))",
                   "intervalFactor": 4,
                   "legendFormat": "io time",
                   "refId": "C",
@@ -2808,7 +2808,7 @@ data:
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "irate(node_network_receive_bytes{instance=~\"$server\",device!~\"lo\"}[5m])",
+                  "expr": "rate(node_network_receive_bytes{instance=~\"$server\",device!~\"lo\"}[5m])",
                   "hide": false,
                   "intervalFactor": 2,
                   "legendFormat": "{{device}}",
@@ -2902,7 +2902,7 @@ data:
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "irate(node_network_transmit_bytes{instance=~\"$server\",device!~\"lo\"}[5m])",
+                  "expr": "rate(node_network_transmit_bytes{instance=~\"$server\",device!~\"lo\"}[5m])",
                   "hide": false,
                   "intervalFactor": 2,
                   "legendFormat": "{{device}}",

--- a/manifests/grafana/grafana-cm.yaml
+++ b/manifests/grafana/grafana-cm.yaml
@@ -2109,7 +2109,7 @@ data:
         ],
         "overwrite": true
     }
-  node-dashboard.json: |-
+  node-dashboard.json: |
     {
       "dashboard": {
       "__inputs": [
@@ -2419,9 +2419,18 @@ data:
                 {
                   "expr": "node_memory_MemTotal{instance=~\"$server\"} - node_memory_MemFree{instance=~\"$server\"}",
                   "intervalFactor": 2,
-                  "legendFormat": "free memory",
+                  "legendFormat": "memory usage",
                   "metric": "memo",
                   "refId": "A",
+                  "step": 4,
+                  "target": ""
+                },
+                {
+                  "expr": "node_memory_MemTotal{instance=~\"$server\"}",
+                  "intervalFactor": 2,
+                  "legendFormat": "memory total",
+                  "metric": "memo",
+                  "refId": "B",
                   "step": 4,
                   "target": ""
                 }
@@ -2429,7 +2438,7 @@ data:
               "thresholds": [],
               "timeFrom": null,
               "timeShift": null,
-              "title": "Free memory",
+              "title": "Memory usage",
               "tooltip": {
                 "msResolution": false,
                 "shared": true,
@@ -2464,9 +2473,9 @@ data:
               "colorBackground": false,
               "colorValue": false,
               "colors": [
-                "rgba(245, 54, 54, 0.9)",
+                "rgba(50, 172, 45, 0.97)",
                 "rgba(237, 129, 40, 0.89)",
-                "rgba(50, 172, 45, 0.97)"
+                "rgba(245, 54, 54, 0.9)"
               ],
               "datasource": "${DS_PROMETHEUS}",
               "editable": true,
@@ -2517,15 +2526,15 @@ data:
               },
               "targets": [
                 {
-                  "expr": "(node_memory_MemFree{instance=~\"$server\"} / node_memory_MemTotal{instance=~\"$server\"}) * 100",
+                  "expr": "((node_memory_MemTotal{instance=~\"$server\"} - node_memory_MemFree{instance=~\"$server\"}) / node_memory_MemTotal{instance=~\"$server\"}) * 100",
                   "intervalFactor": 2,
                   "refId": "A",
                   "step": 60,
                   "target": ""
                 }
               ],
-              "thresholds": "10, 20",
-              "title": "Free memory",
+              "thresholds": "80, 90",
+              "title": "Memory usage",
               "type": "singlestat",
               "valueFontSize": "80%",
               "valueMaps": [
@@ -2631,7 +2640,7 @@ data:
               "thresholds": [],
               "timeFrom": null,
               "timeShift": null,
-              "title": "Disk usage",
+              "title": "Disk I/O",
               "tooltip": {
                 "msResolution": false,
                 "shared": true,
@@ -2666,9 +2675,9 @@ data:
               "colorBackground": false,
               "colorValue": false,
               "colors": [
-                "rgba(245, 54, 54, 0.9)",
+                "rgba(50, 172, 45, 0.97)",
                 "rgba(237, 129, 40, 0.89)",
-                "rgba(50, 172, 45, 0.97)"
+                "rgba(245, 54, 54, 0.9)"
               ],
               "datasource": "${DS_PROMETHEUS}",
               "editable": true,
@@ -2719,15 +2728,15 @@ data:
               },
               "targets": [
                 {
-                  "expr": "sum(node_filesystem_free{device!=\"rootfs\",instance=~\"$server\"}) / sum(node_filesystem_size{device!=\"rootfs\",instance=~\"$server\"})",
+                  "expr": "(sum(node_filesystem_size{device!=\"rootfs\",instance=~\"$server\"}) - sum(node_filesystem_free{device!=\"rootfs\",instance=~\"$server\"})) / sum(node_filesystem_size{device!=\"rootfs\",instance=~\"$server\"})",
                   "intervalFactor": 2,
                   "refId": "A",
                   "step": 60,
                   "target": ""
                 }
               ],
-              "thresholds": "0.10, 0.25",
-              "title": "Free disk space",
+              "thresholds": "0.75, 0.9",
+              "title": "Disk space usage",
               "type": "singlestat",
               "valueFontSize": "80%",
               "valueMaps": [

--- a/manifests/grafana/grafana-cm.yaml
+++ b/manifests/grafana/grafana-cm.yaml
@@ -2212,7 +2212,7 @@ data:
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "100 - (avg by (cpu) (irate(node_cpu{mode=\"idle\", instance=~\"$server\"}[5m])) * 100)",
+                  "expr": "100 - (avg by (cpu) (irate(node_cpu{mode=\"idle\", instance=\"$server\"}[5m])) * 100)",
                   "hide": false,
                   "intervalFactor": 10,
                   "legendFormat": "{{cpu}}",
@@ -2300,7 +2300,7 @@ data:
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "node_load1{instance=~\"$server\"}",
+                  "expr": "node_load1{instance=\"$server\"}",
                   "intervalFactor": 4,
                   "legendFormat": "load 1m",
                   "refId": "A",
@@ -2308,7 +2308,7 @@ data:
                   "target": ""
                 },
                 {
-                  "expr": "node_load5{instance=~\"$server\"}",
+                  "expr": "node_load5{instance=\"$server\"}",
                   "intervalFactor": 4,
                   "legendFormat": "load 5m",
                   "refId": "B",
@@ -2316,7 +2316,7 @@ data:
                   "target": ""
                 },
                 {
-                  "expr": "node_load15{instance=~\"$server\"}",
+                  "expr": "node_load15{instance=\"$server\"}",
                   "intervalFactor": 4,
                   "legendFormat": "load 15m",
                   "refId": "C",
@@ -2417,7 +2417,7 @@ data:
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "node_memory_MemTotal{instance=~\"$server\"} - node_memory_MemFree{instance=~\"$server\"}",
+                  "expr": "node_memory_MemTotal{instance=\"$server\"} - node_memory_MemFree{instance=\"$server\"}",
                   "intervalFactor": 2,
                   "legendFormat": "memory usage",
                   "metric": "memo",
@@ -2426,7 +2426,7 @@ data:
                   "target": ""
                 },
                 {
-                  "expr": "node_memory_MemTotal{instance=~\"$server\"}",
+                  "expr": "node_memory_MemTotal{instance=\"$server\"}",
                   "intervalFactor": 2,
                   "legendFormat": "memory total",
                   "metric": "memo",
@@ -2526,7 +2526,7 @@ data:
               },
               "targets": [
                 {
-                  "expr": "((node_memory_MemTotal{instance=~\"$server\"} - node_memory_MemFree{instance=~\"$server\"}) / node_memory_MemTotal{instance=~\"$server\"}) * 100",
+                  "expr": "((node_memory_MemTotal{instance=\"$server\"} - node_memory_MemFree{instance=\"$server\"}) / node_memory_MemTotal{instance=\"$server\"}) * 100",
                   "intervalFactor": 2,
                   "refId": "A",
                   "step": 60,
@@ -2614,7 +2614,7 @@ data:
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "sum by (instance) (rate(node_disk_bytes_read{instance=~\"$server\"}[2m]))",
+                  "expr": "sum by (instance) (rate(node_disk_bytes_read{instance=\"$server\"}[2m]))",
                   "hide": false,
                   "intervalFactor": 4,
                   "legendFormat": "read",
@@ -2623,14 +2623,14 @@ data:
                   "target": ""
                 },
                 {
-                  "expr": "sum by (instance) (rate(node_disk_bytes_written{instance=~\"$server\"}[2m]))",
+                  "expr": "sum by (instance) (rate(node_disk_bytes_written{instance=\"$server\"}[2m]))",
                   "intervalFactor": 4,
                   "legendFormat": "written",
                   "refId": "B",
                   "step": 8
                 },
                 {
-                  "expr": "sum by (instance) (rate(node_disk_io_time_ms{instance=~\"$server\"}[2m]))",
+                  "expr": "sum by (instance) (rate(node_disk_io_time_ms{instance=\"$server\"}[2m]))",
                   "intervalFactor": 4,
                   "legendFormat": "io time",
                   "refId": "C",
@@ -2728,7 +2728,7 @@ data:
               },
               "targets": [
                 {
-                  "expr": "(sum(node_filesystem_size{device!=\"rootfs\",instance=~\"$server\"}) - sum(node_filesystem_free{device!=\"rootfs\",instance=~\"$server\"})) / sum(node_filesystem_size{device!=\"rootfs\",instance=~\"$server\"})",
+                  "expr": "(sum(node_filesystem_size{device!=\"rootfs\",instance=\"$server\"}) - sum(node_filesystem_free{device!=\"rootfs\",instance=\"$server\"})) / sum(node_filesystem_size{device!=\"rootfs\",instance=\"$server\"})",
                   "intervalFactor": 2,
                   "refId": "A",
                   "step": 60,
@@ -2808,7 +2808,7 @@ data:
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "rate(node_network_receive_bytes{instance=~\"$server\",device!~\"lo\"}[5m])",
+                  "expr": "rate(node_network_receive_bytes{instance=\"$server\",device!~\"lo\"}[5m])",
                   "hide": false,
                   "intervalFactor": 2,
                   "legendFormat": "{{device}}",
@@ -2902,7 +2902,7 @@ data:
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "rate(node_network_transmit_bytes{instance=~\"$server\",device!~\"lo\"}[5m])",
+                  "expr": "rate(node_network_transmit_bytes{instance=\"$server\",device!~\"lo\"}[5m])",
                   "hide": false,
                   "intervalFactor": 2,
                   "legendFormat": "{{device}}",


### PR DESCRIPTION
As reported in #45 the some labels were off as they said "free memory" although memory usage was shown on the chart, and the gauge was actually showing the free memory, which is confusing for a gauge. Same applied to disk charts. Additionally prefer `rate` over `irate` as they should only really spike after ~3 scrapes which is ~2 minutes.

Fixes #45 

@fabxc 

/cc @urzds