### PR TITLE
manifests: don't skip apiserver cert verification

### DIFF
--- a/manifests/prometheus/prometheus-k8s-servicemonitor.yaml
+++ b/manifests/prometheus/prometheus-k8s-servicemonitor.yaml
@@ -19,7 +19,7 @@ spec:
     scheme: https
     tlsConfig:
       caFile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-      insecureSkipVerify: true
+      serverName: kubernetes
     bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
 ---
 apiVersion: monitoring.coreos.com/v1alpha1


### PR DESCRIPTION
As apiserver certs are usually correctly issued we can not skip verifying these, we just need to make sure we ask for the right `serverName`.

@fabxc 