### PR TITLE
[DO NOT MERGE] split used memory into actually used memory, caches and buffers

### DIFF
--- a/assets/grafana/node-dashboard.json
+++ b/assets/grafana/node-dashboard.json
@@ -12,56 +12,47 @@
   ],
   "__requires": [
     {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "4.1.1"
+    },
+    {
       "type": "panel",
       "id": "graph",
       "name": "Graph",
       "version": ""
     },
     {
-      "type": "panel",
-      "id": "singlestat",
-      "name": "Singlestat",
-      "version": ""
-    },
-    {
-      "type": "grafana",
-      "id": "grafana",
-      "name": "Grafana",
-      "version": "3.1.1"
-    },
-    {
       "type": "datasource",
       "id": "prometheus",
       "name": "Prometheus",
       "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "singlestat",
+      "name": "Singlestat",
+      "version": ""
     }
   ],
-  "id": null,
-  "title": "Nodes",
+  "annotations": {
+    "list": []
+  },
   "description": "Dashboard to get an overview of one server",
-  "tags": [
-    "prometheus"
-  ],
-  "style": "dark",
-  "timezone": "browser",
   "editable": true,
+  "gnetId": 22,
+  "graphTooltip": 0,
   "hideControls": false,
-  "sharedCrosshair": false,
+  "id": null,
+  "links": [],
+  "refresh": false,
   "rows": [
     {
       "collapse": false,
-      "editable": true,
       "height": "250px",
       "panels": [
         {
-          "alert": {
-            "crit": {
-              "op": ">"
-            },
-            "warn": {
-              "op": ">"
-            }
-          },
           "alerting": {},
           "aliasColors": {},
           "bars": false,
@@ -69,14 +60,8 @@
           "editable": true,
           "error": false,
           "fill": 1,
-          "grid": {
-            "threshold1": null,
-            "threshold2": null,
-            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-          },
+          "grid": {},
           "id": 3,
-          "isNew": true,
           "legend": {
             "avg": false,
             "current": false,
@@ -120,7 +105,10 @@
           },
           "type": "graph",
           "xaxis": {
-            "show": true
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
           },
           "yaxes": [
             {
@@ -142,14 +130,6 @@
           ]
         },
         {
-          "alert": {
-            "crit": {
-              "op": ">"
-            },
-            "warn": {
-              "op": ">"
-            }
-          },
           "alerting": {},
           "aliasColors": {},
           "bars": false,
@@ -157,14 +137,8 @@
           "editable": true,
           "error": false,
           "fill": 1,
-          "grid": {
-            "threshold1": null,
-            "threshold2": null,
-            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-          },
+          "grid": {},
           "id": 9,
-          "isNew": true,
           "legend": {
             "avg": false,
             "current": false,
@@ -224,7 +198,10 @@
           },
           "type": "graph",
           "xaxis": {
-            "show": true
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
           },
           "yaxes": [
             {
@@ -246,22 +223,18 @@
           ]
         }
       ],
-      "title": "New row"
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": false,
+      "title": "New row",
+      "titleSize": "h6"
     },
     {
       "collapse": false,
-      "editable": true,
       "height": "250px",
       "panels": [
         {
-          "alert": {
-            "crit": {
-              "op": ">"
-            },
-            "warn": {
-              "op": ">"
-            }
-          },
           "alerting": {},
           "aliasColors": {},
           "bars": false,
@@ -269,19 +242,17 @@
           "editable": true,
           "error": false,
           "fill": 1,
-          "grid": {
-            "threshold1": null,
-            "threshold2": null,
-            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-          },
+          "grid": {},
           "id": 4,
-          "isNew": true,
           "legend": {
+            "alignAsTable": false,
             "avg": false,
             "current": false,
+            "hideEmpty": false,
+            "hideZero": false,
             "max": false,
             "min": false,
+            "rightSide": false,
             "show": true,
             "total": false,
             "values": false
@@ -301,26 +272,43 @@
             }
           ],
           "span": 9,
-          "stack": false,
+          "stack": true,
           "steppedLine": false,
           "targets": [
             {
-              "expr": "node_memory_MemTotal{instance=\"$server\"} - node_memory_MemFree{instance=\"$server\"}",
+              "expr": "node_memory_MemTotal{instance=\"$server\"} - node_memory_MemFree{instance=\"$server\"} - node_memory_Buffers{instance=\"$server\"} - node_memory_Cached{instance=\"$server\"}",
+              "hide": false,
+              "interval": "",
               "intervalFactor": 2,
-              "legendFormat": "memory usage",
-              "metric": "memo",
-              "refId": "A",
-              "step": 4,
-              "target": ""
+              "legendFormat": "memory used",
+              "metric": "",
+              "refId": "C",
+              "step": 4
             },
             {
-              "expr": "node_memory_MemTotal{instance=\"$server\"}",
+              "expr": "node_memory_Buffers{instance=\"$server\"}",
+              "interval": "",
               "intervalFactor": 2,
-              "legendFormat": "memory total",
-              "metric": "memo",
-              "refId": "B",
-              "step": 4,
-              "target": ""
+              "legendFormat": "memory buffers",
+              "metric": "",
+              "refId": "E",
+              "step": 4
+            },
+            {
+              "expr": "node_memory_Cached{instance=\"$server\"}",
+              "intervalFactor": 2,
+              "legendFormat": "",
+              "metric": "",
+              "refId": "F",
+              "step": 4
+            },
+            {
+              "expr": "node_memory_MemFree{instance=\"$server\"}",
+              "intervalFactor": 2,
+              "legendFormat": "memory free",
+              "metric": "",
+              "refId": "D",
+              "step": 4
             }
           ],
           "thresholds": [],
@@ -331,11 +319,14 @@
             "msResolution": false,
             "shared": true,
             "sort": 0,
-            "value_type": "cumulative"
+            "value_type": "individual"
           },
           "type": "graph",
           "xaxis": {
-            "show": true
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
           },
           "yaxes": [
             {
@@ -343,7 +334,7 @@
               "label": null,
               "logBase": 1,
               "max": null,
-              "min": null,
+              "min": "0",
               "show": true
             },
             {
@@ -378,7 +369,6 @@
           },
           "id": 5,
           "interval": null,
-          "isNew": true,
           "links": [],
           "mappingType": 1,
           "mappingTypes": [
@@ -414,7 +404,7 @@
           },
           "targets": [
             {
-              "expr": "((node_memory_MemTotal{instance=\"$server\"} - node_memory_MemFree{instance=\"$server\"}) / node_memory_MemTotal{instance=\"$server\"}) * 100",
+              "expr": "((node_memory_MemTotal{instance=\"$server\"} - node_memory_MemFree{instance=\"$server\"}  - node_memory_Buffers{instance=\"$server\"} - node_memory_Cached{instance=\"$server\"}) / node_memory_MemTotal{instance=\"$server\"}) * 100",
               "intervalFactor": 2,
               "refId": "A",
               "step": 60,
@@ -435,22 +425,18 @@
           "valueName": "avg"
         }
       ],
-      "title": "New row"
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": false,
+      "title": "New row",
+      "titleSize": "h6"
     },
     {
       "collapse": false,
-      "editable": true,
       "height": "250px",
       "panels": [
         {
-          "alert": {
-            "crit": {
-              "op": ">"
-            },
-            "warn": {
-              "op": ">"
-            }
-          },
           "alerting": {},
           "aliasColors": {},
           "bars": false,
@@ -458,14 +444,8 @@
           "editable": true,
           "error": false,
           "fill": 1,
-          "grid": {
-            "threshold1": null,
-            "threshold2": null,
-            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-          },
+          "grid": {},
           "id": 6,
-          "isNew": true,
           "legend": {
             "avg": false,
             "current": false,
@@ -537,7 +517,10 @@
           },
           "type": "graph",
           "xaxis": {
-            "show": true
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
           },
           "yaxes": [
             {
@@ -580,7 +563,6 @@
           },
           "id": 7,
           "interval": null,
-          "isNew": true,
           "links": [],
           "mappingType": 1,
           "mappingTypes": [
@@ -637,22 +619,18 @@
           "valueName": "current"
         }
       ],
-      "title": "New row"
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": false,
+      "title": "New row",
+      "titleSize": "h6"
     },
     {
       "collapse": false,
-      "editable": true,
       "height": "250px",
       "panels": [
         {
-          "alert": {
-            "crit": {
-              "op": ">"
-            },
-            "warn": {
-              "op": ">"
-            }
-          },
           "alerting": {},
           "aliasColors": {},
           "bars": false,
@@ -660,14 +638,8 @@
           "editable": true,
           "error": false,
           "fill": 1,
-          "grid": {
-            "threshold1": null,
-            "threshold2": null,
-            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-          },
+          "grid": {},
           "id": 8,
-          "isNew": true,
           "legend": {
             "avg": false,
             "current": false,
@@ -717,7 +689,10 @@
           },
           "type": "graph",
           "xaxis": {
-            "show": true
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
           },
           "yaxes": [
             {
@@ -739,14 +714,6 @@
           ]
         },
         {
-          "alert": {
-            "crit": {
-              "op": ">"
-            },
-            "warn": {
-              "op": ">"
-            }
-          },
           "alerting": {},
           "aliasColors": {},
           "bars": false,
@@ -754,14 +721,8 @@
           "editable": true,
           "error": false,
           "fill": 1,
-          "grid": {
-            "threshold1": null,
-            "threshold2": null,
-            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-          },
+          "grid": {},
           "id": 10,
-          "isNew": true,
           "legend": {
             "avg": false,
             "current": false,
@@ -811,7 +772,10 @@
           },
           "type": "graph",
           "xaxis": {
-            "show": true
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
           },
           "yaxes": [
             {
@@ -833,9 +797,43 @@
           ]
         }
       ],
-      "title": "New row"
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": false,
+      "title": "New row",
+      "titleSize": "h6"
     }
   ],
+  "schemaVersion": 14,
+  "style": "dark",
+  "tags": [
+    "prometheus"
+  ],
+  "templating": {
+    "list": [
+      {
+        "allValue": null,
+        "current": {},
+        "datasource": "${DS_PROMETHEUS}",
+        "hide": 0,
+        "includeAll": false,
+        "label": null,
+        "multi": false,
+        "name": "server",
+        "options": [],
+        "query": "label_values(node_boot_time, instance)",
+        "refresh": 1,
+        "regex": "",
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      }
+    ]
+  },
   "time": {
     "from": "now-1h",
     "to": "now"
@@ -865,38 +863,18 @@
       "30d"
     ]
   },
-  "templating": {
-    "list": [
-      {
-        "current": {},
-        "datasource": "${DS_PROMETHEUS}",
-        "hide": 0,
-        "includeAll": false,
-        "multi": false,
-        "name": "server",
-        "options": [],
-        "query": "label_values(node_boot_time, instance)",
-        "refresh": 1,
-        "type": "query"
-      }
-    ]
-  },
-  "annotations": {
-    "list": []
-  },
-  "refresh": false,
-  "schemaVersion": 12,
-  "version": 1,
-  "links": [],
-  "gnetId": 22
+  "timezone": "browser",
+  "title": "Nodes",
+  "version": 1
 },
-    "inputs": [
-        {
-            "name": "DS_PROMETHEUS",
-            "pluginId": "prometheus",
-            "type": "datasource",
-            "value": "prometheus"
-        }
-    ],
-    "overwrite": true
+  "inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "pluginId": "prometheus",
+      "type": "datasource",
+      "value": "prometheus"
+    }
+  ],
+  "overwrite": true
 }
+

--- a/manifests/grafana/grafana-cm.yaml
+++ b/manifests/grafana/grafana-cm.yaml
@@ -2118,7 +2118,7 @@ data:
         ],
         "overwrite": true
     }
-  node-dashboard.json: |
+  node-dashboard.json: |+
     {
       "dashboard": {
       "__inputs": [
@@ -2133,56 +2133,47 @@ data:
       ],
       "__requires": [
         {
+          "type": "grafana",
+          "id": "grafana",
+          "name": "Grafana",
+          "version": "4.1.1"
+        },
+        {
           "type": "panel",
           "id": "graph",
           "name": "Graph",
           "version": ""
         },
         {
-          "type": "panel",
-          "id": "singlestat",
-          "name": "Singlestat",
-          "version": ""
-        },
-        {
-          "type": "grafana",
-          "id": "grafana",
-          "name": "Grafana",
-          "version": "3.1.1"
-        },
-        {
           "type": "datasource",
           "id": "prometheus",
           "name": "Prometheus",
           "version": "1.0.0"
+        },
+        {
+          "type": "panel",
+          "id": "singlestat",
+          "name": "Singlestat",
+          "version": ""
         }
       ],
-      "id": null,
-      "title": "Nodes",
+      "annotations": {
+        "list": []
+      },
       "description": "Dashboard to get an overview of one server",
-      "tags": [
-        "prometheus"
-      ],
-      "style": "dark",
-      "timezone": "browser",
       "editable": true,
+      "gnetId": 22,
+      "graphTooltip": 0,
       "hideControls": false,
-      "sharedCrosshair": false,
+      "id": null,
+      "links": [],
+      "refresh": false,
       "rows": [
         {
           "collapse": false,
-          "editable": true,
           "height": "250px",
           "panels": [
             {
-              "alert": {
-                "crit": {
-                  "op": ">"
-                },
-                "warn": {
-                  "op": ">"
-                }
-              },
               "alerting": {},
               "aliasColors": {},
               "bars": false,
@@ -2190,14 +2181,8 @@ data:
               "editable": true,
               "error": false,
               "fill": 1,
-              "grid": {
-                "threshold1": null,
-                "threshold2": null,
-                "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                "threshold2Color": "rgba(234, 112, 112, 0.22)"
-              },
+              "grid": {},
               "id": 3,
-              "isNew": true,
               "legend": {
                 "avg": false,
                 "current": false,
@@ -2241,7 +2226,10 @@ data:
               },
               "type": "graph",
               "xaxis": {
-                "show": true
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
               },
               "yaxes": [
                 {
@@ -2263,14 +2251,6 @@ data:
               ]
             },
             {
-              "alert": {
-                "crit": {
-                  "op": ">"
-                },
-                "warn": {
-                  "op": ">"
-                }
-              },
               "alerting": {},
               "aliasColors": {},
               "bars": false,
@@ -2278,14 +2258,8 @@ data:
               "editable": true,
               "error": false,
               "fill": 1,
-              "grid": {
-                "threshold1": null,
-                "threshold2": null,
-                "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                "threshold2Color": "rgba(234, 112, 112, 0.22)"
-              },
+              "grid": {},
               "id": 9,
-              "isNew": true,
               "legend": {
                 "avg": false,
                 "current": false,
@@ -2345,7 +2319,10 @@ data:
               },
               "type": "graph",
               "xaxis": {
-                "show": true
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
               },
               "yaxes": [
                 {
@@ -2367,22 +2344,18 @@ data:
               ]
             }
           ],
-          "title": "New row"
+          "repeat": null,
+          "repeatIteration": null,
+          "repeatRowId": null,
+          "showTitle": false,
+          "title": "New row",
+          "titleSize": "h6"
         },
         {
           "collapse": false,
-          "editable": true,
           "height": "250px",
           "panels": [
             {
-              "alert": {
-                "crit": {
-                  "op": ">"
-                },
-                "warn": {
-                  "op": ">"
-                }
-              },
               "alerting": {},
               "aliasColors": {},
               "bars": false,
@@ -2390,19 +2363,17 @@ data:
               "editable": true,
               "error": false,
               "fill": 1,
-              "grid": {
-                "threshold1": null,
-                "threshold2": null,
-                "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                "threshold2Color": "rgba(234, 112, 112, 0.22)"
-              },
+              "grid": {},
               "id": 4,
-              "isNew": true,
               "legend": {
+                "alignAsTable": false,
                 "avg": false,
                 "current": false,
+                "hideEmpty": false,
+                "hideZero": false,
                 "max": false,
                 "min": false,
+                "rightSide": false,
                 "show": true,
                 "total": false,
                 "values": false
@@ -2422,26 +2393,43 @@ data:
                 }
               ],
               "span": 9,
-              "stack": false,
+              "stack": true,
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "node_memory_MemTotal{instance=\"$server\"} - node_memory_MemFree{instance=\"$server\"}",
+                  "expr": "node_memory_MemTotal{instance=\"$server\"} - node_memory_MemFree{instance=\"$server\"} - node_memory_Buffers{instance=\"$server\"} - node_memory_Cached{instance=\"$server\"}",
+                  "hide": false,
+                  "interval": "",
                   "intervalFactor": 2,
-                  "legendFormat": "memory usage",
-                  "metric": "memo",
-                  "refId": "A",
-                  "step": 4,
-                  "target": ""
+                  "legendFormat": "memory used",
+                  "metric": "",
+                  "refId": "C",
+                  "step": 4
                 },
                 {
-                  "expr": "node_memory_MemTotal{instance=\"$server\"}",
+                  "expr": "node_memory_Buffers{instance=\"$server\"}",
+                  "interval": "",
                   "intervalFactor": 2,
-                  "legendFormat": "memory total",
-                  "metric": "memo",
-                  "refId": "B",
-                  "step": 4,
-                  "target": ""
+                  "legendFormat": "memory buffers",
+                  "metric": "",
+                  "refId": "E",
+                  "step": 4
+                },
+                {
+                  "expr": "node_memory_Cached{instance=\"$server\"}",
+                  "intervalFactor": 2,
+                  "legendFormat": "",
+                  "metric": "",
+                  "refId": "F",
+                  "step": 4
+                },
+                {
+                  "expr": "node_memory_MemFree{instance=\"$server\"}",
+                  "intervalFactor": 2,
+                  "legendFormat": "memory free",
+                  "metric": "",
+                  "refId": "D",
+                  "step": 4
                 }
               ],
               "thresholds": [],
@@ -2452,11 +2440,14 @@ data:
                 "msResolution": false,
                 "shared": true,
                 "sort": 0,
-                "value_type": "cumulative"
+                "value_type": "individual"
               },
               "type": "graph",
               "xaxis": {
-                "show": true
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
               },
               "yaxes": [
                 {
@@ -2464,7 +2455,7 @@ data:
                   "label": null,
                   "logBase": 1,
                   "max": null,
-                  "min": null,
+                  "min": "0",
                   "show": true
                 },
                 {
@@ -2499,7 +2490,6 @@ data:
               },
               "id": 5,
               "interval": null,
-              "isNew": true,
               "links": [],
               "mappingType": 1,
               "mappingTypes": [
@@ -2535,7 +2525,7 @@ data:
               },
               "targets": [
                 {
-                  "expr": "((node_memory_MemTotal{instance=\"$server\"} - node_memory_MemFree{instance=\"$server\"}) / node_memory_MemTotal{instance=\"$server\"}) * 100",
+                  "expr": "((node_memory_MemTotal{instance=\"$server\"} - node_memory_MemFree{instance=\"$server\"}  - node_memory_Buffers{instance=\"$server\"} - node_memory_Cached{instance=\"$server\"}) / node_memory_MemTotal{instance=\"$server\"}) * 100",
                   "intervalFactor": 2,
                   "refId": "A",
                   "step": 60,
@@ -2556,22 +2546,18 @@ data:
               "valueName": "avg"
             }
           ],
-          "title": "New row"
+          "repeat": null,
+          "repeatIteration": null,
+          "repeatRowId": null,
+          "showTitle": false,
+          "title": "New row",
+          "titleSize": "h6"
         },
         {
           "collapse": false,
-          "editable": true,
           "height": "250px",
           "panels": [
             {
-              "alert": {
-                "crit": {
-                  "op": ">"
-                },
-                "warn": {
-                  "op": ">"
-                }
-              },
               "alerting": {},
               "aliasColors": {},
               "bars": false,
@@ -2579,14 +2565,8 @@ data:
               "editable": true,
               "error": false,
               "fill": 1,
-              "grid": {
-                "threshold1": null,
-                "threshold2": null,
-                "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                "threshold2Color": "rgba(234, 112, 112, 0.22)"
-              },
+              "grid": {},
               "id": 6,
-              "isNew": true,
               "legend": {
                 "avg": false,
                 "current": false,
@@ -2658,7 +2638,10 @@ data:
               },
               "type": "graph",
               "xaxis": {
-                "show": true
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
               },
               "yaxes": [
                 {
@@ -2701,7 +2684,6 @@ data:
               },
               "id": 7,
               "interval": null,
-              "isNew": true,
               "links": [],
               "mappingType": 1,
               "mappingTypes": [
@@ -2758,22 +2740,18 @@ data:
               "valueName": "current"
             }
           ],
-          "title": "New row"
+          "repeat": null,
+          "repeatIteration": null,
+          "repeatRowId": null,
+          "showTitle": false,
+          "title": "New row",
+          "titleSize": "h6"
         },
         {
           "collapse": false,
-          "editable": true,
           "height": "250px",
           "panels": [
             {
-              "alert": {
-                "crit": {
-                  "op": ">"
-                },
-                "warn": {
-                  "op": ">"
-                }
-              },
               "alerting": {},
               "aliasColors": {},
               "bars": false,
@@ -2781,14 +2759,8 @@ data:
               "editable": true,
               "error": false,
               "fill": 1,
-              "grid": {
-                "threshold1": null,
-                "threshold2": null,
-                "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                "threshold2Color": "rgba(234, 112, 112, 0.22)"
-              },
+              "grid": {},
               "id": 8,
-              "isNew": true,
               "legend": {
                 "avg": false,
                 "current": false,
@@ -2838,7 +2810,10 @@ data:
               },
               "type": "graph",
               "xaxis": {
-                "show": true
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
               },
               "yaxes": [
                 {
@@ -2860,14 +2835,6 @@ data:
               ]
             },
             {
-              "alert": {
-                "crit": {
-                  "op": ">"
-                },
-                "warn": {
-                  "op": ">"
-                }
-              },
               "alerting": {},
               "aliasColors": {},
               "bars": false,
@@ -2875,14 +2842,8 @@ data:
               "editable": true,
               "error": false,
               "fill": 1,
-              "grid": {
-                "threshold1": null,
-                "threshold2": null,
-                "threshold1Color": "rgba(216, 200, 27, 0.27)",
-                "threshold2Color": "rgba(234, 112, 112, 0.22)"
-              },
+              "grid": {},
               "id": 10,
-              "isNew": true,
               "legend": {
                 "avg": false,
                 "current": false,
@@ -2932,7 +2893,10 @@ data:
               },
               "type": "graph",
               "xaxis": {
-                "show": true
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
               },
               "yaxes": [
                 {
@@ -2954,9 +2918,43 @@ data:
               ]
             }
           ],
-          "title": "New row"
+          "repeat": null,
+          "repeatIteration": null,
+          "repeatRowId": null,
+          "showTitle": false,
+          "title": "New row",
+          "titleSize": "h6"
         }
       ],
+      "schemaVersion": 14,
+      "style": "dark",
+      "tags": [
+        "prometheus"
+      ],
+      "templating": {
+        "list": [
+          {
+            "allValue": null,
+            "current": {},
+            "datasource": "${DS_PROMETHEUS}",
+            "hide": 0,
+            "includeAll": false,
+            "label": null,
+            "multi": false,
+            "name": "server",
+            "options": [],
+            "query": "label_values(node_boot_time, instance)",
+            "refresh": 1,
+            "regex": "",
+            "sort": 0,
+            "tagValuesQuery": "",
+            "tags": [],
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+          }
+        ]
+      },
       "time": {
         "from": "now-1h",
         "to": "now"
@@ -2986,41 +2984,21 @@ data:
           "30d"
         ]
       },
-      "templating": {
-        "list": [
-          {
-            "current": {},
-            "datasource": "${DS_PROMETHEUS}",
-            "hide": 0,
-            "includeAll": false,
-            "multi": false,
-            "name": "server",
-            "options": [],
-            "query": "label_values(node_boot_time, instance)",
-            "refresh": 1,
-            "type": "query"
-          }
-        ]
-      },
-      "annotations": {
-        "list": []
-      },
-      "refresh": false,
-      "schemaVersion": 12,
-      "version": 1,
-      "links": [],
-      "gnetId": 22
+      "timezone": "browser",
+      "title": "Nodes",
+      "version": 1
     },
-        "inputs": [
-            {
-                "name": "DS_PROMETHEUS",
-                "pluginId": "prometheus",
-                "type": "datasource",
-                "value": "prometheus"
-            }
-        ],
-        "overwrite": true
+      "inputs": [
+        {
+          "name": "DS_PROMETHEUS",
+          "pluginId": "prometheus",
+          "type": "datasource",
+          "value": "prometheus"
+        }
+      ],
+      "overwrite": true
     }
+
   prometheus-datasource.json: |
     {
         "access": "proxy",


### PR DESCRIPTION
Generated by editing dashboard in live Grafana, exporting to file,
wrapping file with as specified here:
https://github.com/coreos/kube-prometheus/issues/53#issuecomment-283603064

This PR is not intended for merging, but instead for viewing how changes made in live Grafana are looks like, see #53 