### PR TITLE
Add missing adapter to build snippet

### DIFF
--- a/examples/jsonnet-build-snippet/build-snippet.jsonnet
+++ b/examples/jsonnet-build-snippet/build-snippet.jsonnet
@@ -4,4 +4,5 @@
 { ['kube-state-metrics-' + name]: kp.kubeStateMetrics[name] for name in std.objectFields(kp.kubeStateMetrics) } +
 { ['alertmanager-' + name]: kp.alertmanager[name] for name in std.objectFields(kp.alertmanager) } +
 { ['prometheus-' + name]: kp.prometheus[name] for name in std.objectFields(kp.prometheus) } +
+{ ['prometheus-adapter-' + name]: kp.prometheusAdapter[name] for name in std.objectFields(kp.prometheusAdapter) } +
 { ['grafana-' + name]: kp.grafana[name] for name in std.objectFields(kp.grafana) }


### PR DESCRIPTION
Just noticed a difference between this file and the example.jsonnet.

Originally by @jgustie in https://github.com/coreos/prometheus-operator/pull/2556