### PR TITLE
Remove node interface down

### DIFF
--- a/jsonnet/kube-prometheus/alerts/node.libsonnet
+++ b/jsonnet/kube-prometheus/alerts/node.libsonnet
@@ -80,19 +80,6 @@
             },
           },
           {
-            alert: 'NodeNetworkInterfaceDown',
-            annotations: {
-              message: 'Network interface "{{ $labels.device }}" down on node-exporter {{ $labels.namespace }}/{{ $labels.pod }}"',
-            },
-            expr: |||
-              node_network_up{%(nodeExporterSelector)s,%(hostNetworkInterfaceSelector)s} == 0
-            ||| % $._config,
-            'for': '2m',
-            labels: {
-              severity: 'warning',
-            },
-          },
-          {
             alert: 'NodeNetworkInterfaceFlapping',
             annotations: {
               message: 'Network interface "{{ $labels.device }}" changing it\'s up status often on node-exporter {{ $labels.namespace }}/{{ $labels.pod }}"',

--- a/jsonnetfile.lock.json
+++ b/jsonnetfile.lock.json
@@ -8,7 +8,7 @@
                     "subdir": "jsonnet/kube-prometheus"
                 }
             },
-            "version": "62f823e34706811421f44af9894ad77d47bc2293"
+            "version": "9524cbb40665826997322df6f3431ca0609ecb62"
         },
         {
             "name": "ksonnet",
@@ -28,7 +28,7 @@
                     "subdir": ""
                 }
             },
-            "version": "3991660410dab201bb1f60b84d26e027c6c877e4"
+            "version": "c4acc6e194632ca134fe56de7e4e4e9c7cef2221"
         },
         {
             "name": "grafonnet",
@@ -48,7 +48,7 @@
                     "subdir": "grafana-builder"
                 }
             },
-            "version": "2c635c3310c6e61720871ac94d6d2572e37b83f7"
+            "version": "11d1552f120f2d9e8d932a671faf67beae91503a"
         },
         {
             "name": "grafana",
@@ -78,7 +78,7 @@
                     "subdir": "Documentation/etcd-mixin"
                 }
             },
-            "version": "a621d807f061e1dd635033a8d6bc261461429e27"
+            "version": "f29b1ada19713544b698dab8c94c97cfa1e83dac"
         }
     ]
 }

--- a/manifests/prometheus-rules.yaml
+++ b/manifests/prometheus-rules.yaml
@@ -962,15 +962,6 @@ spec:
       for: 2m
       labels:
         severity: warning
-    - alert: NodeNetworkInterfaceDown
-      annotations:
-        message: Network interface "{{ $labels.device }}" down on node-exporter {{
-          $labels.namespace }}/{{ $labels.pod }}"
-      expr: |
-        node_network_up{job="node-exporter",device!~"veth.+"} == 0
-      for: 2m
-      labels:
-        severity: warning
     - alert: NodeNetworkInterfaceFlapping
       annotations:
         message: Network interface "{{ $labels.device }}" changing it's up status


### PR DESCRIPTION
This alert is too aggressive and alerts on interfaces that are expected to be down. I talked to the SDN team for OpenShift and they mentioned we'll need to go with another strategy but for now best is to remove this alert.

https://bugzilla.redhat.com/show_bug.cgi?id=1700057

@mxinden @metalmatze @squat @s-urbaniak @paulfantom 