### PR TITLE
Update to Alertmanager v0.16.2

### DIFF
--- a/jsonnet/kube-prometheus/alertmanager/alertmanager.libsonnet
+++ b/jsonnet/kube-prometheus/alertmanager/alertmanager.libsonnet
@@ -5,7 +5,7 @@ local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
     namespace: 'default',
 
     versions+:: {
-      alertmanager: 'v0.16.1',
+      alertmanager: 'v0.16.2',
     },
 
     imageRepos+:: {

--- a/jsonnetfile.lock.json
+++ b/jsonnetfile.lock.json
@@ -8,7 +8,7 @@
                     "subdir": "jsonnet/kube-prometheus"
                 }
             },
-            "version": "9524cbb40665826997322df6f3431ca0609ecb62"
+            "version": "cb4b913c32d053cddb5d4a2d572eaf11b55d8971"
         },
         {
             "name": "ksonnet",

--- a/manifests/alertmanager-alertmanager.yaml
+++ b/manifests/alertmanager-alertmanager.yaml
@@ -15,4 +15,4 @@ spec:
     runAsNonRoot: true
     runAsUser: 1000
   serviceAccountName: alertmanager-main
-  version: v0.16.1
+  version: v0.16.2


### PR DESCRIPTION
https://github.com/prometheus/alertmanager/releases

> Updating to v0.16.2 is recommended for all users using the Slack, Pagerduty,
Hipchat, Wechat, VictorOps and Pushover notifier, as connection errors could
leak secrets embedded in the notifier's URL to stdout.

> - [BUGFIX] Redact notifier URL from logs to not leak secrets embedded in the URL (#1822, #1825)
> - [BUGFIX] Allow sending of unauthenticated SMTP requests when smtp_auth_username is not supplied (#1739)

