### PR TITLE
jsonnet/prometheus-adapter: add metrics to default user-facing roles

### DIFF
--- a/jsonnet/kube-prometheus/prometheus-adapter/prometheus-adapter.libsonnet
+++ b/jsonnet/kube-prometheus/prometheus-adapter/prometheus-adapter.libsonnet
@@ -184,6 +184,25 @@ local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
       clusterRole.mixin.metadata.withName('resource-metrics-server-resources') +
       clusterRole.withRules(rules),
 
+    clusterRoleAggregatedMetricsReader:
+      local clusterRole = k.rbac.v1.clusterRole;
+      local policyRule = clusterRole.rulesType;
+
+      local rules =
+        policyRule.new() +
+        policyRule.withApiGroups(['metrics.k8s.io']) +
+        policyRule.withResources(['pods']) +
+        policyRule.withVerbs(['get','list','watch']);
+
+      clusterRole.new() +
+      clusterRole.mixin.metadata.withName('system:aggregated-metrics-reader') +
+      clusterRole.mixin.metadata.withLabels({
+        "rbac.authorization.k8s.io/aggregate-to-admin": "true",
+        "rbac.authorization.k8s.io/aggregate-to-edit": "true",
+        "rbac.authorization.k8s.io/aggregate-to-view": "true",
+      }) +
+      clusterRole.withRules(rules),
+
     roleBindingAuthReader:
       local roleBinding = k.rbac.v1.roleBinding;
 

--- a/jsonnetfile.lock.json
+++ b/jsonnetfile.lock.json
@@ -8,7 +8,7 @@
                     "subdir": "jsonnet/kube-prometheus"
                 }
             },
-            "version": "a7bb5d1a1f37152f0e45912550a1a80b29fcd28a"
+            "version": "1fbf75767a59d7fff5a7d716657349fcd884e4d3"
         },
         {
             "name": "ksonnet",

--- a/kustomization.yaml
+++ b/kustomization.yaml
@@ -40,6 +40,7 @@ resources:
 - ./manifests/node-exporter-serviceMonitor.yaml
 - ./manifests/prometheus-adapter-apiService.yaml
 - ./manifests/prometheus-adapter-clusterRole.yaml
+- ./manifests/prometheus-adapter-clusterRoleAggregatedMetricsReader.yaml
 - ./manifests/prometheus-adapter-clusterRoleBinding.yaml
 - ./manifests/prometheus-adapter-clusterRoleBindingDelegator.yaml
 - ./manifests/prometheus-adapter-clusterRoleServerResources.yaml

--- a/manifests/prometheus-adapter-clusterRoleAggregatedMetricsReader.yaml
+++ b/manifests/prometheus-adapter-clusterRoleAggregatedMetricsReader.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+  name: system:aggregated-metrics-reader
+rules:
+- apiGroups:
+  - metrics.k8s.io
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch


### PR DESCRIPTION
Currently, only cluster wide admins have the permissions to view metrics
resources. This fixes it by adding a read-only cluster role which includes
aggregation labels to synthesize permission rules for standard user-facing
roles according to [1].

Note that only the "pods" resource is granted as reading "nodes" metrics
requires a cluster wide permission.

[1]
https://kubernetes.io/docs/reference/access-authn-authz/rbac/#user-facing-roles

/cc @brancz @metalmatze