### PR TITLE
Update kubespray libsonnet for kubespray v2.9.0

### DIFF
--- a/jsonnet/kube-prometheus/kube-prometheus-kubespray.libsonnet
+++ b/jsonnet/kube-prometheus/kube-prometheus-kubespray.libsonnet
@@ -3,16 +3,54 @@ local service = k.core.v1.service;
 local servicePort = k.core.v1.service.mixin.spec.portsType;
 
 {
+
+  _config+:: {
+    jobs+: {
+      CoreDNS: 'job="coredns"',
+    },
+  },
+
   prometheus+: {
     kubeControllerManagerPrometheusDiscoveryService:
-      service.new('kube-controller-manager-prometheus-discovery', { 'k8s-app': 'kube-controller-manager' }, servicePort.newNamed('http-metrics', 10252, 10252)) +
+      service.new('kube-controller-manager-prometheus-discovery', { 'component': 'kube-controller-manager' }, servicePort.newNamed('http-metrics', 10252, 10252)) +
       service.mixin.metadata.withNamespace('kube-system') +
       service.mixin.metadata.withLabels({ 'k8s-app': 'kube-controller-manager' }) +
       service.mixin.spec.withClusterIp('None'),
     kubeSchedulerPrometheusDiscoveryService:
-      service.new('kube-scheduler-prometheus-discovery', { 'k8s-app': 'kube-scheduler' }, servicePort.newNamed('http-metrics', 10251, 10251)) +
+      service.new('kube-scheduler-prometheus-discovery', { 'component': 'kube-scheduler' }, servicePort.newNamed('http-metrics', 10251, 10251)) +
       service.mixin.metadata.withNamespace('kube-system') +
       service.mixin.metadata.withLabels({ 'k8s-app': 'kube-scheduler' }) +
       service.mixin.spec.withClusterIp('None'),
+
+    serviceMonitorCoreDNS+: {
+      spec+: {
+        selector: {
+          matchLabels: {
+            'k8s-app': 'coredns',
+          },
+        },
+      },
+    },
+
+    serviceMonitorKubeScheduler+: {
+      spec+: {
+        selector+: {
+          matchLabels: {
+            'k8s-app': 'kube-scheduler',
+          },
+        },
+      },
+    },
+
+    serviceMonitorKubeControllerManager+: {
+      spec+: {
+        selector+: {
+          matchLabels: {
+            'k8s-app': 'kube-controller-manager',
+          },
+        },
+      },
+    },
+
   },
 }


### PR DESCRIPTION
These changes have been tested against kubespray v2.9.0 on a baremetal
cluster created from scratch. They have not been tested against previous
versions of kubespray.

Fixes:

https://github.com/coreos/kube-prometheus/issues/79