### PR TITLE
Pin kubernetes-mixin v0.1.0

### DIFF
--- a/jsonnet/kube-prometheus/jsonnetfile.json
+++ b/jsonnet/kube-prometheus/jsonnetfile.json
@@ -18,7 +18,7 @@
                     "subdir": ""
                 }
             },
-            "version": "master"
+            "version": "v0.1.0"
         },
         {
             "name": "grafana",

--- a/jsonnet/kube-prometheus/jsonnetfile.json
+++ b/jsonnet/kube-prometheus/jsonnetfile.json
@@ -18,7 +18,7 @@
                     "subdir": ""
                 }
             },
-            "version": "v0.1.0"
+            "version": "release-0.1"
         },
         {
             "name": "grafana",

--- a/jsonnetfile.lock.json
+++ b/jsonnetfile.lock.json
@@ -28,7 +28,7 @@
                     "subdir": ""
                 }
             },
-            "version": "7360753d27aa428758c918434503c1c35afcd3bb"
+            "version": "5107f34c39baf5360ed0be84ea9a0cc5fb25fabc"
         },
         {
             "name": "grafonnet",

--- a/manifests/grafana-dashboardDefinitions.yaml
+++ b/manifests/grafana-dashboardDefinitions.yaml
@@ -3048,24 +3048,6 @@ items:
                                   "unit": "short"
                               },
                               {
-                                  "alias": "CPU Usage",
-                                  "colorMode": null,
-                                  "colors": [
-
-                                  ],
-                                  "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                                  "decimals": 2,
-                                  "link": false,
-                                  "linkTooltip": "Drill down",
-                                  "linkUrl": "",
-                                  "pattern": "Value #C",
-                                  "thresholds": [
-
-                                  ],
-                                  "type": "number",
-                                  "unit": "short"
-                              },
-                              {
                                   "alias": "Memory Usage",
                                   "colorMode": null,
                                   "colors": [
@@ -3076,7 +3058,7 @@ items:
                                   "link": false,
                                   "linkTooltip": "Drill down",
                                   "linkUrl": "",
-                                  "pattern": "Value #D",
+                                  "pattern": "Value #C",
                                   "thresholds": [
 
                                   ],
@@ -3094,7 +3076,7 @@ items:
                                   "link": false,
                                   "linkTooltip": "Drill down",
                                   "linkUrl": "",
-                                  "pattern": "Value #E",
+                                  "pattern": "Value #D",
                                   "thresholds": [
 
                                   ],
@@ -3112,7 +3094,7 @@ items:
                                   "link": false,
                                   "linkTooltip": "Drill down",
                                   "linkUrl": "",
-                                  "pattern": "Value #F",
+                                  "pattern": "Value #E",
                                   "thresholds": [
 
                                   ],
@@ -3130,7 +3112,7 @@ items:
                                   "link": false,
                                   "linkTooltip": "Drill down",
                                   "linkUrl": "",
-                                  "pattern": "Value #G",
+                                  "pattern": "Value #F",
                                   "thresholds": [
 
                                   ],
@@ -3148,7 +3130,7 @@ items:
                                   "link": false,
                                   "linkTooltip": "Drill down",
                                   "linkUrl": "",
-                                  "pattern": "Value #H",
+                                  "pattern": "Value #G",
                                   "thresholds": [
 
                                   ],


### PR DESCRIPTION
We should use the released version of kubernetes-mixin. We can always release another kubernetes-mixin v0.1.x if we need anything updated.