### PR TITLE
Note prometheus adapter component

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Components included in this package:
 * Highly available [Prometheus](https://prometheus.io/)
 * Highly available [Alertmanager](https://github.com/prometheus/alertmanager)
 * [Prometheus node-exporter](https://github.com/prometheus/node_exporter)
+* [Prometheus Adapter for Kubernetes Metrics APIs](https://github.com/DirectXMan12/k8s-prometheus-adapter)
 * [kube-state-metrics](https://github.com/kubernetes/kube-state-metrics)
 * [Grafana](https://grafana.com/)
 


### PR DESCRIPTION
Per coreos/prometheus-operator#2519

I think it could better be advertised that you should not need to install metrics-server AND the prometheus operator.