### PR TITLE
Fixes Grafana config in ingress example

### DIFF
--- a/examples/ingress.jsonnet
+++ b/examples/ingress.jsonnet
@@ -10,21 +10,21 @@ local kp =
   {
     _config+:: {
       namespace: 'monitoring',
+      grafana+:: {
+        config+: {
+          sections+: {
+            server+: {
+              root_url: 'http://grafana.example.com/',
+            },
+          },
+        },
+      },
     },
     // Configure External URL's per application
     alertmanager+:: {
       alertmanager+: {
         spec+: {
           externalUrl: 'http://alertmanager.example.com',
-        },
-      },
-    },
-    grafana+:: {
-      config+: {
-        sections+: {
-          server+: {
-            root_url: 'http://grafana.example.com/',
-          },
         },
       },
     },


### PR DESCRIPTION
The example resulted in: 

```yaml
sections:
  server:
    root_url: http://grafana.example.com/
```

Now results in the proper:
```yaml
apiVersion: v1
data:
  grafana.ini: W3NlcnZlcl0Kcm9vdF91cmwgPSBodHRwOi8vZ3JhZmFuYS5leGFtcGxlLmNvbS8K
kind: Secret
metadata:
  name: grafana-config
  namespace: monitoring
type: Opaque
```

If there is a nicer to way to achieve this please let me know! I am just getting familair with jsonnet :)