### PR TITLE
update mem limit of kube-rbac-proxy container in pod of node-exporter to 60M 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ all: generate fmt test
 .PHONY: generate-in-docker
 generate-in-docker:
 	@echo ">> Compiling assets and generating Kubernetes manifests"
-	$(CONTAINER_CMD) $(MAKE) $(MFLAGS) generate
+	$(CONTAINER_CMD) make $(MFLAGS) generate
 
 generate: manifests **.md
 
@@ -42,7 +42,7 @@ test-e2e:
 
 test-in-docker:
 	@echo ">> Compiling assets and generating Kubernetes manifests"
-	$(CONTAINER_CMD) $(MAKE) $(MFLAGS) test
+	$(CONTAINER_CMD) make $(MFLAGS) test
 
 $(JB_BINARY):
 	go get -u github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb

--- a/jsonnet/kube-prometheus/node-exporter/node-exporter.libsonnet
+++ b/jsonnet/kube-prometheus/node-exporter/node-exporter.libsonnet
@@ -125,7 +125,7 @@ local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
         // it so that the scheduler can decide if the pod is schedulable.
         container.withPorts(containerPort.new($._config.nodeExporter.port) + containerPort.withHostPort($._config.nodeExporter.port) + containerPort.withName('https')) +
         container.mixin.resources.withRequests({ cpu: '10m', memory: '20Mi' }) +
-        container.mixin.resources.withLimits({ cpu: '20m', memory: '40Mi' }) +
+        container.mixin.resources.withLimits({ cpu: '20m', memory: '60Mi' }) +
         container.withEnv([ip]);
 
       local c = [nodeExporter, proxy];

--- a/jsonnetfile.lock.json
+++ b/jsonnetfile.lock.json
@@ -8,7 +8,7 @@
                     "subdir": "jsonnet/kube-prometheus"
                 }
             },
-            "version": "81b9c9f9f6886ba1fbd61b05cdf0cc4f4d95eba8"
+            "version": "6562f95c143531d09d8c3d8629d8de98ab65a43d"
         },
         {
             "name": "ksonnet",

--- a/manifests/node-exporter-daemonset.yaml
+++ b/manifests/node-exporter-daemonset.yaml
@@ -61,7 +61,7 @@ spec:
         resources:
           limits:
             cpu: 20m
-            memory: 40Mi
+            memory: 60Mi
           requests:
             cpu: 10m
             memory: 20Mi


### PR DESCRIPTION
update mem limit of kube-rbac-proxy container in pod of node-exporter to 60M 
fix #91