### PR TITLE
Incorporate “stale `manifests/`” fix from `release-0.1`

### DIFF
--- a/jsonnet/kube-prometheus/jsonnetfile.json
+++ b/jsonnet/kube-prometheus/jsonnetfile.json
@@ -38,7 +38,7 @@
                     "subdir": "jsonnet/prometheus-operator"
                 }
             },
-            "version": "v0.30.0"
+            "version": "release-0.30"
         },
         {
             "name": "etcd-mixin",

--- a/jsonnetfile.lock.json
+++ b/jsonnetfile.lock.json
@@ -8,11 +8,7 @@
                     "subdir": "jsonnet/kube-prometheus"
                 }
             },
-<<<<<<< HEAD
-            "version": "107028fff38b6e3dce3e1ef110222474fb01b31c"
-=======
-            "version": "e85d2f3b64c65f81aec7093dda880376a6719fe1"
->>>>>>> release-0.1
+            "version": "df8a5b51b4e05fc7ba1a168346a80cbc9bec48d3"
         },
         {
             "name": "ksonnet",

--- a/jsonnetfile.lock.json
+++ b/jsonnetfile.lock.json
@@ -8,7 +8,11 @@
                     "subdir": "jsonnet/kube-prometheus"
                 }
             },
+<<<<<<< HEAD
             "version": "107028fff38b6e3dce3e1ef110222474fb01b31c"
+=======
+            "version": "e85d2f3b64c65f81aec7093dda880376a6719fe1"
+>>>>>>> release-0.1
         },
         {
             "name": "ksonnet",
@@ -28,7 +32,7 @@
                     "subdir": ""
                 }
             },
-            "version": "ae58a33e85b191a8760a8d1bd8d3cda2fd046d05"
+            "version": "af494738e1709998696ffbce9296063a20c80692"
         },
         {
             "name": "grafonnet",
@@ -38,7 +42,7 @@
                     "subdir": "grafonnet"
                 }
             },
-            "version": "a6896d19aedc46ecf80dd64967191b9fd6f75f45"
+            "version": "bcd95ffa00fc4a58d34832f88f4b366effeb63ad"
         },
         {
             "name": "grafana-builder",
@@ -48,7 +52,7 @@
                     "subdir": "grafana-builder"
                 }
             },
-            "version": "a73d6c3e7f5804fc7a16f592b42a62384605046c"
+            "version": "de367fc28346fbf5a9afdef887ea20d9ffb7e927"
         },
         {
             "name": "grafana",
@@ -58,7 +62,7 @@
                     "subdir": "grafana"
                 }
             },
-            "version": "b6db6bdbdc8d7f2f8834a8044897ea6322a0f6ad"
+            "version": "c27d2792764867cdaf6484f067cc875cb8aef2f6"
         },
         {
             "name": "prometheus-operator",
@@ -68,7 +72,7 @@
                     "subdir": "jsonnet/prometheus-operator"
                 }
             },
-            "version": "7a25bf6b6bb2347dacb235659b73bc210117acc7"
+            "version": "18fbf558ab7f8809fd610a3dc50bf483508dc1bb"
         },
         {
             "name": "etcd-mixin",
@@ -78,7 +82,7 @@
                     "subdir": "Documentation/etcd-mixin"
                 }
             },
-            "version": "919b93b742c76b12a83bdf8885fa75f11db6bcac"
+            "version": "d6280f9ea54849e5364545ca34bdac0a58317569"
         }
     ]
 }

--- a/manifests/0prometheus-operator-0alertmanagerCustomResourceDefinition.yaml
+++ b/manifests/0prometheus-operator-0alertmanagerCustomResourceDefinition.yaml
@@ -94,6 +94,7 @@ spec:
                                   required:
                                   - key
                                   - operator
+                                  type: object
                                 type: array
                               matchFields:
                                 description: A list of node selector requirements
@@ -127,7 +128,9 @@ spec:
                                   required:
                                   - key
                                   - operator
+                                  type: object
                                 type: array
+                            type: object
                           weight:
                             description: Weight associated with matching the corresponding
                               nodeSelectorTerm, in the range 1-100.
@@ -136,6 +139,7 @@ spec:
                         required:
                         - weight
                         - preference
+                        type: object
                       type: array
                     requiredDuringSchedulingIgnoredDuringExecution:
                       description: A node selector represents the union of the results
@@ -184,6 +188,7 @@ spec:
                                   required:
                                   - key
                                   - operator
+                                  type: object
                                 type: array
                               matchFields:
                                 description: A list of node selector requirements
@@ -217,10 +222,14 @@ spec:
                                   required:
                                   - key
                                   - operator
+                                  type: object
                                 type: array
+                            type: object
                           type: array
                       required:
                       - nodeSelectorTerms
+                      type: object
+                  type: object
                 podAffinity:
                   description: Pod affinity is a group of inter pod affinity scheduling
                     rules.
@@ -287,6 +296,7 @@ spec:
                                       required:
                                       - key
                                       - operator
+                                      type: object
                                     type: array
                                   matchLabels:
                                     description: matchLabels is a map of {key,value}
@@ -296,6 +306,7 @@ spec:
                                       and the values array contains only "value".
                                       The requirements are ANDed.
                                     type: object
+                                type: object
                               namespaces:
                                 description: namespaces specifies which namespaces
                                   the labelSelector applies to (matches against);
@@ -314,6 +325,7 @@ spec:
                                 type: string
                             required:
                             - topologyKey
+                            type: object
                           weight:
                             description: weight associated with matching the corresponding
                               podAffinityTerm, in the range 1-100.
@@ -322,6 +334,7 @@ spec:
                         required:
                         - weight
                         - podAffinityTerm
+                        type: object
                       type: array
                     requiredDuringSchedulingIgnoredDuringExecution:
                       description: If the affinity requirements specified by this
@@ -378,6 +391,7 @@ spec:
                                   required:
                                   - key
                                   - operator
+                                  type: object
                                 type: array
                               matchLabels:
                                 description: matchLabels is a map of {key,value} pairs.
@@ -386,6 +400,7 @@ spec:
                                   is "key", the operator is "In", and the values array
                                   contains only "value". The requirements are ANDed.
                                 type: object
+                            type: object
                           namespaces:
                             description: namespaces specifies which namespaces the
                               labelSelector applies to (matches against); null or
@@ -404,7 +419,9 @@ spec:
                             type: string
                         required:
                         - topologyKey
+                        type: object
                       type: array
+                  type: object
                 podAntiAffinity:
                   description: Pod anti affinity is a group of inter pod anti affinity
                     scheduling rules.
@@ -472,6 +489,7 @@ spec:
                                       required:
                                       - key
                                       - operator
+                                      type: object
                                     type: array
                                   matchLabels:
                                     description: matchLabels is a map of {key,value}
@@ -481,6 +499,7 @@ spec:
                                       and the values array contains only "value".
                                       The requirements are ANDed.
                                     type: object
+                                type: object
                               namespaces:
                                 description: namespaces specifies which namespaces
                                   the labelSelector applies to (matches against);
@@ -499,6 +518,7 @@ spec:
                                 type: string
                             required:
                             - topologyKey
+                            type: object
                           weight:
                             description: weight associated with matching the corresponding
                               podAffinityTerm, in the range 1-100.
@@ -507,6 +527,7 @@ spec:
                         required:
                         - weight
                         - podAffinityTerm
+                        type: object
                       type: array
                     requiredDuringSchedulingIgnoredDuringExecution:
                       description: If the anti-affinity requirements specified by
@@ -563,6 +584,7 @@ spec:
                                   required:
                                   - key
                                   - operator
+                                  type: object
                                 type: array
                               matchLabels:
                                 description: matchLabels is a map of {key,value} pairs.
@@ -571,6 +593,7 @@ spec:
                                   is "key", the operator is "In", and the values array
                                   contains only "value". The requirements are ANDed.
                                 type: object
+                            type: object
                           namespaces:
                             description: namespaces specifies which namespaces the
                               labelSelector applies to (matches against); null or
@@ -589,7 +612,10 @@ spec:
                             type: string
                         required:
                         - topologyKey
+                        type: object
                       type: array
+                  type: object
+              type: object
             baseImage:
               description: Base image that is used to deploy pods, without tag.
               type: string
@@ -672,6 +698,7 @@ spec:
                                   type: boolean
                               required:
                               - key
+                              type: object
                             fieldRef:
                               description: ObjectFieldSelector selects an APIVersioned
                                 field of an object.
@@ -686,6 +713,7 @@ spec:
                                   type: string
                               required:
                               - fieldPath
+                              type: object
                             resourceFieldRef:
                               description: ResourceFieldSelector represents container
                                 resources (cpu, memory) and their output format
@@ -700,6 +728,7 @@ spec:
                                   type: string
                               required:
                               - resource
+                              type: object
                             secretKeyRef:
                               description: SecretKeySelector selects a key of a Secret.
                               properties:
@@ -716,8 +745,11 @@ spec:
                                   type: boolean
                               required:
                               - key
+                              type: object
+                          type: object
                       required:
                       - name
+                      type: object
                     type: array
                   envFrom:
                     description: List of sources to populate environment variables
@@ -743,6 +775,7 @@ spec:
                             optional:
                               description: Specify whether the ConfigMap must be defined
                               type: boolean
+                          type: object
                         prefix:
                           description: An optional identifier to prepend to each key
                             in the ConfigMap. Must be a C_IDENTIFIER.
@@ -759,6 +792,8 @@ spec:
                             optional:
                               description: Specify whether the Secret must be defined
                               type: boolean
+                          type: object
+                      type: object
                     type: array
                   image:
                     description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images
@@ -798,6 +833,7 @@ spec:
                                 items:
                                   type: string
                                 type: array
+                            type: object
                           httpGet:
                             description: HTTPGetAction describes an action based on
                               HTTP Get requests.
@@ -823,6 +859,7 @@ spec:
                                   required:
                                   - name
                                   - value
+                                  type: object
                                 type: array
                               path:
                                 description: Path to access on the HTTP server.
@@ -837,6 +874,7 @@ spec:
                                 type: string
                             required:
                             - port
+                            type: object
                           tcpSocket:
                             description: TCPSocketAction describes an action based
                               on opening a socket
@@ -851,6 +889,8 @@ spec:
                                 - type: integer
                             required:
                             - port
+                            type: object
+                        type: object
                       preStop:
                         description: Handler defines a specific action that should
                           be taken
@@ -871,6 +911,7 @@ spec:
                                 items:
                                   type: string
                                 type: array
+                            type: object
                           httpGet:
                             description: HTTPGetAction describes an action based on
                               HTTP Get requests.
@@ -896,6 +937,7 @@ spec:
                                   required:
                                   - name
                                   - value
+                                  type: object
                                 type: array
                               path:
                                 description: Path to access on the HTTP server.
@@ -910,6 +952,7 @@ spec:
                                 type: string
                             required:
                             - port
+                            type: object
                           tcpSocket:
                             description: TCPSocketAction describes an action based
                               on opening a socket
@@ -924,6 +967,9 @@ spec:
                                 - type: integer
                             required:
                             - port
+                            type: object
+                        type: object
+                    type: object
                   livenessProbe:
                     description: Probe describes a health check to be performed against
                       a container to determine whether it is alive or ready to receive
@@ -944,6 +990,7 @@ spec:
                             items:
                               type: string
                             type: array
+                        type: object
                       failureThreshold:
                         description: Minimum consecutive failures for the probe to
                           be considered failed after having succeeded. Defaults to
@@ -975,6 +1022,7 @@ spec:
                               required:
                               - name
                               - value
+                              type: object
                             type: array
                           path:
                             description: Path to access on the HTTP server.
@@ -989,6 +1037,7 @@ spec:
                             type: string
                         required:
                         - port
+                        type: object
                       initialDelaySeconds:
                         description: 'Number of seconds after the container has started
                           before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
@@ -1019,12 +1068,14 @@ spec:
                             - type: integer
                         required:
                         - port
+                        type: object
                       timeoutSeconds:
                         description: 'Number of seconds after which the probe times
                           out. Defaults to 1 second. Minimum value is 1. More info:
                           https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                         format: int32
                         type: integer
+                    type: object
                   name:
                     description: Name of the container specified as a DNS_LABEL. Each
                       container in a pod must have a unique name (DNS_LABEL). Cannot
@@ -1069,6 +1120,7 @@ spec:
                           type: string
                       required:
                       - containerPort
+                      type: object
                     type: array
                   readinessProbe:
                     description: Probe describes a health check to be performed against
@@ -1090,6 +1142,7 @@ spec:
                             items:
                               type: string
                             type: array
+                        type: object
                       failureThreshold:
                         description: Minimum consecutive failures for the probe to
                           be considered failed after having succeeded. Defaults to
@@ -1121,6 +1174,7 @@ spec:
                               required:
                               - name
                               - value
+                              type: object
                             type: array
                           path:
                             description: Path to access on the HTTP server.
@@ -1135,6 +1189,7 @@ spec:
                             type: string
                         required:
                         - port
+                        type: object
                       initialDelaySeconds:
                         description: 'Number of seconds after the container has started
                           before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
@@ -1165,12 +1220,14 @@ spec:
                             - type: integer
                         required:
                         - port
+                        type: object
                       timeoutSeconds:
                         description: 'Number of seconds after which the probe times
                           out. Defaults to 1 second. Minimum value is 1. More info:
                           https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                         format: int32
                         type: integer
+                    type: object
                   resources:
                     description: ResourceRequirements describes the compute resource
                       requirements.
@@ -1185,6 +1242,7 @@ spec:
                           it defaults to Limits if that is explicitly specified, otherwise
                           to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                         type: object
+                    type: object
                   securityContext:
                     description: SecurityContext holds security configuration that
                       will be applied to a container. Some fields are present in both
@@ -1213,6 +1271,7 @@ spec:
                             items:
                               type: string
                             type: array
+                        type: object
                       privileged:
                         description: Run container in privileged mode. Processes in
                           privileged containers are essentially equivalent to root
@@ -1274,6 +1333,8 @@ spec:
                             description: User is a SELinux user label that applies
                               to the container.
                             type: string
+                        type: object
+                    type: object
                   stdin:
                     description: Whether this container should allocate a buffer for
                       stdin in the container runtime. If this is not set, reads from
@@ -1331,6 +1392,7 @@ spec:
                       required:
                       - name
                       - devicePath
+                      type: object
                     type: array
                   volumeMounts:
                     description: Pod volumes to mount into the container's filesystem.
@@ -1360,9 +1422,18 @@ spec:
                           description: Path within the volume from which the container's
                             volume should be mounted. Defaults to "" (volume's root).
                           type: string
+                        subPathExpr:
+                          description: Expanded path within the volume from which
+                            the container's volume should be mounted. Behaves similarly
+                            to SubPath but environment variable references $(VAR_NAME)
+                            are expanded using the container's environment. Defaults
+                            to "" (volume's root). SubPathExpr and SubPath are mutually
+                            exclusive. This field is alpha in 1.14.
+                          type: string
                       required:
                       - name
                       - mountPath
+                      type: object
                     type: array
                   workingDir:
                     description: Container's working directory. If not specified,
@@ -1371,6 +1442,7 @@ spec:
                     type: string
                 required:
                 - name
+                type: object
               type: array
             externalUrl:
               description: The external URL the Alertmanager instances will be available
@@ -1394,12 +1466,16 @@ spec:
                   name:
                     description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                     type: string
+                type: object
               type: array
             listenLocal:
               description: ListenLocal makes the Alertmanager server listen on loopback,
                 so that it does not bind against the Pod IP. Note this is only for
                 the Alertmanager UI, not the gossip communication.
               type: boolean
+            logFormat:
+              description: Log format for Alertmanager to be configured with.
+              type: string
             logLevel:
               description: Log level for Alertmanager to be configured with.
               type: string
@@ -1485,6 +1561,7 @@ spec:
                             type: string
                         required:
                         - name
+                        type: object
                       type: array
                     result:
                       description: Status is a return value for calls that don't return
@@ -1537,6 +1614,7 @@ spec:
                                       the cause of the error. If this value is empty
                                       there is no information available.
                                     type: string
+                                type: object
                               type: array
                             group:
                               description: The group attribute of the resource associated
@@ -1566,6 +1644,7 @@ spec:
                                 single resource which can be described). More info:
                                 http://kubernetes.io/docs/user-guide/identifiers#uids'
                               type: string
+                          type: object
                         kind:
                           description: 'Kind is a string value representing the REST
                             resource this object represents. Servers may infer this
@@ -1607,6 +1686,7 @@ spec:
                               description: selfLink is a URL representing this object.
                                 Populated by the system. Read-only.
                               type: string
+                          type: object
                         reason:
                           description: A machine-readable description of why this
                             operation is in the "Failure" status. If this value is
@@ -1617,14 +1697,54 @@ spec:
                           description: 'Status of the operation. One of: "Success"
                             or "Failure". More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status'
                           type: string
+                      type: object
                   required:
                   - pending
+                  type: object
                 labels:
                   description: 'Map of string keys and values that can be used to
                     organize and categorize (scope and select) objects. May match
                     selectors of replication controllers and services. More info:
                     http://kubernetes.io/docs/user-guide/labels'
                   type: object
+                managedFields:
+                  description: |-
+                    ManagedFields maps workflow-id and version to the set of fields that are managed by that workflow. This is mostly for internal housekeeping, and users typically shouldn't need to set or understand this field. A workflow can be the user's name, a controller's name, or the name of a specific apply path like "ci-cd". The set of fields is always in the version that the workflow used when modifying the object.
+
+                    This field is alpha and can be changed or removed without notice.
+                  items:
+                    description: ManagedFieldsEntry is a workflow-id, a FieldSet and
+                      the group version of the resource that the fieldset applies
+                      to.
+                    properties:
+                      apiVersion:
+                        description: APIVersion defines the version of this resource
+                          that this field set applies to. The format is "group/version"
+                          just like the top-level APIVersion field. It is necessary
+                          to track the version of a field set because it cannot be
+                          automatically converted.
+                        type: string
+                      fields:
+                        description: 'Fields stores a set of fields in a data structure
+                          like a Trie. To understand how this is used, see: https://github.com/kubernetes-sigs/structured-merge-diff'
+                        type: object
+                      manager:
+                        description: Manager is an identifier of the workflow managing
+                          these fields.
+                        type: string
+                      operation:
+                        description: Operation is the type of operation which lead
+                          to this ManagedFieldsEntry being created. The only valid
+                          values for this field are 'Apply' and 'Update'.
+                        type: string
+                      time:
+                        description: Time is a wrapper around time.Time which supports
+                          correct marshaling to YAML and JSON.  Wrappers are provided
+                          for many of the factory methods that the time package offers.
+                        format: date-time
+                        type: string
+                    type: object
+                  type: array
                 name:
                   description: 'Name must be unique within a namespace. Is required
                     when creating resources, although some resources may allow a client
@@ -1678,6 +1798,7 @@ spec:
                     - kind
                     - name
                     - uid
+                    type: object
                   type: array
                 resourceVersion:
                   description: |-
@@ -1695,6 +1816,7 @@ spec:
 
                     Populated by the system. Read-only. More info: http://kubernetes.io/docs/user-guide/identifiers#uids
                   type: string
+              type: object
             priorityClassName:
               description: Priority class assigned to the Pods
               type: string
@@ -1717,6 +1839,7 @@ spec:
                     to Limits if that is explicitly specified, otherwise to an implementation-defined
                     value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                   type: object
+              type: object
             retention:
               description: Time duration Alertmanager shall retain data for. Default
                 is '120h', and must match the regular expression `[0-9]+(ms|s|m|h)`
@@ -1795,6 +1918,7 @@ spec:
                       description: User is a SELinux user label that applies to the
                         container.
                       type: string
+                  type: object
                 supplementalGroups:
                   description: A list of groups applied to the first process run in
                     each container, in addition to the container's primary GID.  If
@@ -1819,7 +1943,9 @@ spec:
                     required:
                     - name
                     - value
+                    type: object
                   type: array
+              type: object
             serviceAccountName:
               description: ServiceAccountName is the name of the ServiceAccount to
                 use to run the Prometheus Pods.
@@ -1846,6 +1972,7 @@ spec:
                         Must be an empty string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                       type: string
                     sizeLimit: {}
+                  type: object
                 volumeClaimTemplate:
                   description: PersistentVolumeClaim is a user's request for and claim
                     to a persistent volume
@@ -1943,6 +2070,7 @@ spec:
                                     type: string
                                 required:
                                 - name
+                                type: object
                               type: array
                             result:
                               description: Status is a return value for calls that
@@ -1998,6 +2126,7 @@ spec:
                                               of the cause of the error. If this value
                                               is empty there is no information available.
                                             type: string
+                                        type: object
                                       type: array
                                     group:
                                       description: The group attribute of the resource
@@ -2028,6 +2157,7 @@ spec:
                                         is a single resource which can be described).
                                         More info: http://kubernetes.io/docs/user-guide/identifiers#uids'
                                       type: string
+                                  type: object
                                 kind:
                                   description: 'Kind is a string value representing
                                     the REST resource this object represents. Servers
@@ -2074,6 +2204,7 @@ spec:
                                       description: selfLink is a URL representing
                                         this object. Populated by the system. Read-only.
                                       type: string
+                                  type: object
                                 reason:
                                   description: A machine-readable description of why
                                     this operation is in the "Failure" status. If
@@ -2085,14 +2216,57 @@ spec:
                                   description: 'Status of the operation. One of: "Success"
                                     or "Failure". More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status'
                                   type: string
+                              type: object
                           required:
                           - pending
+                          type: object
                         labels:
                           description: 'Map of string keys and values that can be
                             used to organize and categorize (scope and select) objects.
                             May match selectors of replication controllers and services.
                             More info: http://kubernetes.io/docs/user-guide/labels'
                           type: object
+                        managedFields:
+                          description: |-
+                            ManagedFields maps workflow-id and version to the set of fields that are managed by that workflow. This is mostly for internal housekeeping, and users typically shouldn't need to set or understand this field. A workflow can be the user's name, a controller's name, or the name of a specific apply path like "ci-cd". The set of fields is always in the version that the workflow used when modifying the object.
+
+                            This field is alpha and can be changed or removed without notice.
+                          items:
+                            description: ManagedFieldsEntry is a workflow-id, a FieldSet
+                              and the group version of the resource that the fieldset
+                              applies to.
+                            properties:
+                              apiVersion:
+                                description: APIVersion defines the version of this
+                                  resource that this field set applies to. The format
+                                  is "group/version" just like the top-level APIVersion
+                                  field. It is necessary to track the version of a
+                                  field set because it cannot be automatically converted.
+                                type: string
+                              fields:
+                                description: 'Fields stores a set of fields in a data
+                                  structure like a Trie. To understand how this is
+                                  used, see: https://github.com/kubernetes-sigs/structured-merge-diff'
+                                type: object
+                              manager:
+                                description: Manager is an identifier of the workflow
+                                  managing these fields.
+                                type: string
+                              operation:
+                                description: Operation is the type of operation which
+                                  lead to this ManagedFieldsEntry being created. The
+                                  only valid values for this field are 'Apply' and
+                                  'Update'.
+                                type: string
+                              time:
+                                description: Time is a wrapper around time.Time which
+                                  supports correct marshaling to YAML and JSON.  Wrappers
+                                  are provided for many of the factory methods that
+                                  the time package offers.
+                                format: date-time
+                                type: string
+                            type: object
+                          type: array
                         name:
                           description: 'Name must be unique within a namespace. Is
                             required when creating resources, although some resources
@@ -2149,6 +2323,7 @@ spec:
                             - kind
                             - name
                             - uid
+                            type: object
                           type: array
                         resourceVersion:
                           description: |-
@@ -2166,6 +2341,7 @@ spec:
 
                             Populated by the system. Read-only. More info: http://kubernetes.io/docs/user-guide/identifiers#uids
                           type: string
+                      type: object
                     spec:
                       description: PersistentVolumeClaimSpec describes the common
                         attributes of storage devices and allows a Source for provider-specific
@@ -2197,6 +2373,7 @@ spec:
                           required:
                           - kind
                           - name
+                          type: object
                         resources:
                           description: ResourceRequirements describes the compute
                             resource requirements.
@@ -2212,6 +2389,7 @@ spec:
                                 explicitly specified, otherwise to an implementation-defined
                                 value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                               type: object
+                          type: object
                         selector:
                           description: A label selector is a label query over a set
                             of resources. The result of matchLabels and matchExpressions
@@ -2248,6 +2426,7 @@ spec:
                                 required:
                                 - key
                                 - operator
+                                type: object
                               type: array
                             matchLabels:
                               description: matchLabels is a map of {key,value} pairs.
@@ -2256,6 +2435,7 @@ spec:
                                 is "key", the operator is "In", and the values array
                                 contains only "value". The requirements are ANDed.
                               type: object
+                          type: object
                         storageClassName:
                           description: 'Name of the StorageClass required by the claim.
                             More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
@@ -2269,6 +2449,7 @@ spec:
                           description: VolumeName is the binding reference to the
                             PersistentVolume backing this claim.
                           type: string
+                      type: object
                     status:
                       description: PersistentVolumeClaimStatus is the current status
                         of a persistent volume claim.
@@ -2323,10 +2504,14 @@ spec:
                             required:
                             - type
                             - status
+                            type: object
                           type: array
                         phase:
                           description: Phase represents the current phase of PersistentVolumeClaim.
                           type: string
+                      type: object
+                  type: object
+              type: object
             tag:
               description: Tag of Alertmanager container image to be deployed. Defaults
                 to the value of `version`. Version is ignored if Tag is set.
@@ -2369,10 +2554,12 @@ spec:
                       If the operator is Exists, the value should be empty, otherwise
                       just a regular string.
                     type: string
+                type: object
               type: array
             version:
               description: Version the cluster should be on.
               type: string
+          type: object
         status:
           description: 'AlertmanagerStatus is the most recent observed status of the
             Alertmanager cluster. Read-only. Not included when requesting from the
@@ -2408,4 +2595,6 @@ spec:
           - updatedReplicas
           - availableReplicas
           - unavailableReplicas
+          type: object
+      type: object
   version: v1

--- a/manifests/0prometheus-operator-0prometheusCustomResourceDefinition.yaml
+++ b/manifests/0prometheus-operator-0prometheusCustomResourceDefinition.yaml
@@ -41,6 +41,7 @@ spec:
                   type: boolean
               required:
               - key
+              type: object
             additionalAlertRelabelConfigs:
               description: SecretKeySelector selects a key of a Secret.
               properties:
@@ -56,6 +57,7 @@ spec:
                   type: boolean
               required:
               - key
+              type: object
             additionalScrapeConfigs:
               description: SecretKeySelector selects a key of a Secret.
               properties:
@@ -71,6 +73,7 @@ spec:
                   type: boolean
               required:
               - key
+              type: object
             affinity:
               description: Affinity is a group of affinity scheduling rules.
               properties:
@@ -133,6 +136,7 @@ spec:
                                   required:
                                   - key
                                   - operator
+                                  type: object
                                 type: array
                               matchFields:
                                 description: A list of node selector requirements
@@ -166,7 +170,9 @@ spec:
                                   required:
                                   - key
                                   - operator
+                                  type: object
                                 type: array
+                            type: object
                           weight:
                             description: Weight associated with matching the corresponding
                               nodeSelectorTerm, in the range 1-100.
@@ -175,6 +181,7 @@ spec:
                         required:
                         - weight
                         - preference
+                        type: object
                       type: array
                     requiredDuringSchedulingIgnoredDuringExecution:
                       description: A node selector represents the union of the results
@@ -223,6 +230,7 @@ spec:
                                   required:
                                   - key
                                   - operator
+                                  type: object
                                 type: array
                               matchFields:
                                 description: A list of node selector requirements
@@ -256,10 +264,14 @@ spec:
                                   required:
                                   - key
                                   - operator
+                                  type: object
                                 type: array
+                            type: object
                           type: array
                       required:
                       - nodeSelectorTerms
+                      type: object
+                  type: object
                 podAffinity:
                   description: Pod affinity is a group of inter pod affinity scheduling
                     rules.
@@ -326,6 +338,7 @@ spec:
                                       required:
                                       - key
                                       - operator
+                                      type: object
                                     type: array
                                   matchLabels:
                                     description: matchLabels is a map of {key,value}
@@ -335,6 +348,7 @@ spec:
                                       and the values array contains only "value".
                                       The requirements are ANDed.
                                     type: object
+                                type: object
                               namespaces:
                                 description: namespaces specifies which namespaces
                                   the labelSelector applies to (matches against);
@@ -353,6 +367,7 @@ spec:
                                 type: string
                             required:
                             - topologyKey
+                            type: object
                           weight:
                             description: weight associated with matching the corresponding
                               podAffinityTerm, in the range 1-100.
@@ -361,6 +376,7 @@ spec:
                         required:
                         - weight
                         - podAffinityTerm
+                        type: object
                       type: array
                     requiredDuringSchedulingIgnoredDuringExecution:
                       description: If the affinity requirements specified by this
@@ -417,6 +433,7 @@ spec:
                                   required:
                                   - key
                                   - operator
+                                  type: object
                                 type: array
                               matchLabels:
                                 description: matchLabels is a map of {key,value} pairs.
@@ -425,6 +442,7 @@ spec:
                                   is "key", the operator is "In", and the values array
                                   contains only "value". The requirements are ANDed.
                                 type: object
+                            type: object
                           namespaces:
                             description: namespaces specifies which namespaces the
                               labelSelector applies to (matches against); null or
@@ -443,7 +461,9 @@ spec:
                             type: string
                         required:
                         - topologyKey
+                        type: object
                       type: array
+                  type: object
                 podAntiAffinity:
                   description: Pod anti affinity is a group of inter pod anti affinity
                     scheduling rules.
@@ -511,6 +531,7 @@ spec:
                                       required:
                                       - key
                                       - operator
+                                      type: object
                                     type: array
                                   matchLabels:
                                     description: matchLabels is a map of {key,value}
@@ -520,6 +541,7 @@ spec:
                                       and the values array contains only "value".
                                       The requirements are ANDed.
                                     type: object
+                                type: object
                               namespaces:
                                 description: namespaces specifies which namespaces
                                   the labelSelector applies to (matches against);
@@ -538,6 +560,7 @@ spec:
                                 type: string
                             required:
                             - topologyKey
+                            type: object
                           weight:
                             description: weight associated with matching the corresponding
                               podAffinityTerm, in the range 1-100.
@@ -546,6 +569,7 @@ spec:
                         required:
                         - weight
                         - podAffinityTerm
+                        type: object
                       type: array
                     requiredDuringSchedulingIgnoredDuringExecution:
                       description: If the anti-affinity requirements specified by
@@ -602,6 +626,7 @@ spec:
                                   required:
                                   - key
                                   - operator
+                                  type: object
                                 type: array
                               matchLabels:
                                 description: matchLabels is a map of {key,value} pairs.
@@ -610,6 +635,7 @@ spec:
                                   is "key", the operator is "In", and the values array
                                   contains only "value". The requirements are ANDed.
                                 type: object
+                            type: object
                           namespaces:
                             description: namespaces specifies which namespaces the
                               labelSelector applies to (matches against); null or
@@ -628,7 +654,10 @@ spec:
                             type: string
                         required:
                         - topologyKey
+                        type: object
                       type: array
+                  type: object
+              type: object
             alerting:
               description: AlertingSpec defines parameters for alerting configuration
                 of Prometheus servers.
@@ -679,13 +708,16 @@ spec:
                           serverName:
                             description: Used to verify the hostname for the targets.
                             type: string
+                        type: object
                     required:
                     - namespace
                     - name
                     - port
+                    type: object
                   type: array
               required:
               - alertmanagers
+              type: object
             apiserverConfig:
               description: 'APIServerConfig defines a host and auth methods to access
                 apiserver. More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#kubernetes_sd_config'
@@ -710,6 +742,7 @@ spec:
                           type: boolean
                       required:
                       - key
+                      type: object
                     username:
                       description: SecretKeySelector selects a key of a Secret.
                       properties:
@@ -726,6 +759,8 @@ spec:
                           type: boolean
                       required:
                       - key
+                      type: object
+                  type: object
                 bearerToken:
                   description: Bearer token for accessing apiserver.
                   type: string
@@ -754,8 +789,10 @@ spec:
                     serverName:
                       description: Used to verify the hostname for the targets.
                       type: string
+                  type: object
               required:
               - host
+              type: object
             baseImage:
               description: Base image to use for a Prometheus deployment.
               type: string
@@ -767,8 +804,16 @@ spec:
                 type: string
               type: array
             containers:
-              description: Containers allows injecting additional containers. This
-                is meant to allow adding an authentication proxy to a Prometheus pod.
+              description: 'Containers allows injecting additional containers or modifying
+                operator generated containers. This can be used to allow adding an
+                authentication proxy to a Prometheus pod or to change the behavior
+                of an operator generated container. Containers described here modify
+                an operator generated container if they share the same name and modifications
+                are done via a strategic merge patch. The current container names
+                are: `prometheus`, `prometheus-config-reloader`, `rules-configmap-reloader`,
+                and `thanos-sidecar`. Overriding containers is entirely outside the
+                scope of what the maintainers will support and by doing so, you accept
+                that this behaviour may break at any time without notice.'
               items:
                 description: A single application container that you want to run within
                   a pod.
@@ -837,6 +882,7 @@ spec:
                                   type: boolean
                               required:
                               - key
+                              type: object
                             fieldRef:
                               description: ObjectFieldSelector selects an APIVersioned
                                 field of an object.
@@ -851,6 +897,7 @@ spec:
                                   type: string
                               required:
                               - fieldPath
+                              type: object
                             resourceFieldRef:
                               description: ResourceFieldSelector represents container
                                 resources (cpu, memory) and their output format
@@ -865,6 +912,7 @@ spec:
                                   type: string
                               required:
                               - resource
+                              type: object
                             secretKeyRef:
                               description: SecretKeySelector selects a key of a Secret.
                               properties:
@@ -881,8 +929,11 @@ spec:
                                   type: boolean
                               required:
                               - key
+                              type: object
+                          type: object
                       required:
                       - name
+                      type: object
                     type: array
                   envFrom:
                     description: List of sources to populate environment variables
@@ -908,6 +959,7 @@ spec:
                             optional:
                               description: Specify whether the ConfigMap must be defined
                               type: boolean
+                          type: object
                         prefix:
                           description: An optional identifier to prepend to each key
                             in the ConfigMap. Must be a C_IDENTIFIER.
@@ -924,6 +976,8 @@ spec:
                             optional:
                               description: Specify whether the Secret must be defined
                               type: boolean
+                          type: object
+                      type: object
                     type: array
                   image:
                     description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images
@@ -963,6 +1017,7 @@ spec:
                                 items:
                                   type: string
                                 type: array
+                            type: object
                           httpGet:
                             description: HTTPGetAction describes an action based on
                               HTTP Get requests.
@@ -988,6 +1043,7 @@ spec:
                                   required:
                                   - name
                                   - value
+                                  type: object
                                 type: array
                               path:
                                 description: Path to access on the HTTP server.
@@ -1002,6 +1058,7 @@ spec:
                                 type: string
                             required:
                             - port
+                            type: object
                           tcpSocket:
                             description: TCPSocketAction describes an action based
                               on opening a socket
@@ -1016,6 +1073,8 @@ spec:
                                 - type: integer
                             required:
                             - port
+                            type: object
+                        type: object
                       preStop:
                         description: Handler defines a specific action that should
                           be taken
@@ -1036,6 +1095,7 @@ spec:
                                 items:
                                   type: string
                                 type: array
+                            type: object
                           httpGet:
                             description: HTTPGetAction describes an action based on
                               HTTP Get requests.
@@ -1061,6 +1121,7 @@ spec:
                                   required:
                                   - name
                                   - value
+                                  type: object
                                 type: array
                               path:
                                 description: Path to access on the HTTP server.
@@ -1075,6 +1136,7 @@ spec:
                                 type: string
                             required:
                             - port
+                            type: object
                           tcpSocket:
                             description: TCPSocketAction describes an action based
                               on opening a socket
@@ -1089,6 +1151,9 @@ spec:
                                 - type: integer
                             required:
                             - port
+                            type: object
+                        type: object
+                    type: object
                   livenessProbe:
                     description: Probe describes a health check to be performed against
                       a container to determine whether it is alive or ready to receive
@@ -1109,6 +1174,7 @@ spec:
                             items:
                               type: string
                             type: array
+                        type: object
                       failureThreshold:
                         description: Minimum consecutive failures for the probe to
                           be considered failed after having succeeded. Defaults to
@@ -1140,6 +1206,7 @@ spec:
                               required:
                               - name
                               - value
+                              type: object
                             type: array
                           path:
                             description: Path to access on the HTTP server.
@@ -1154,6 +1221,7 @@ spec:
                             type: string
                         required:
                         - port
+                        type: object
                       initialDelaySeconds:
                         description: 'Number of seconds after the container has started
                           before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
@@ -1184,12 +1252,14 @@ spec:
                             - type: integer
                         required:
                         - port
+                        type: object
                       timeoutSeconds:
                         description: 'Number of seconds after which the probe times
                           out. Defaults to 1 second. Minimum value is 1. More info:
                           https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                         format: int32
                         type: integer
+                    type: object
                   name:
                     description: Name of the container specified as a DNS_LABEL. Each
                       container in a pod must have a unique name (DNS_LABEL). Cannot
@@ -1234,6 +1304,7 @@ spec:
                           type: string
                       required:
                       - containerPort
+                      type: object
                     type: array
                   readinessProbe:
                     description: Probe describes a health check to be performed against
@@ -1255,6 +1326,7 @@ spec:
                             items:
                               type: string
                             type: array
+                        type: object
                       failureThreshold:
                         description: Minimum consecutive failures for the probe to
                           be considered failed after having succeeded. Defaults to
@@ -1286,6 +1358,7 @@ spec:
                               required:
                               - name
                               - value
+                              type: object
                             type: array
                           path:
                             description: Path to access on the HTTP server.
@@ -1300,6 +1373,7 @@ spec:
                             type: string
                         required:
                         - port
+                        type: object
                       initialDelaySeconds:
                         description: 'Number of seconds after the container has started
                           before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
@@ -1330,12 +1404,14 @@ spec:
                             - type: integer
                         required:
                         - port
+                        type: object
                       timeoutSeconds:
                         description: 'Number of seconds after which the probe times
                           out. Defaults to 1 second. Minimum value is 1. More info:
                           https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                         format: int32
                         type: integer
+                    type: object
                   resources:
                     description: ResourceRequirements describes the compute resource
                       requirements.
@@ -1350,6 +1426,7 @@ spec:
                           it defaults to Limits if that is explicitly specified, otherwise
                           to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                         type: object
+                    type: object
                   securityContext:
                     description: SecurityContext holds security configuration that
                       will be applied to a container. Some fields are present in both
@@ -1378,6 +1455,7 @@ spec:
                             items:
                               type: string
                             type: array
+                        type: object
                       privileged:
                         description: Run container in privileged mode. Processes in
                           privileged containers are essentially equivalent to root
@@ -1439,6 +1517,8 @@ spec:
                             description: User is a SELinux user label that applies
                               to the container.
                             type: string
+                        type: object
+                    type: object
                   stdin:
                     description: Whether this container should allocate a buffer for
                       stdin in the container runtime. If this is not set, reads from
@@ -1496,6 +1576,7 @@ spec:
                       required:
                       - name
                       - devicePath
+                      type: object
                     type: array
                   volumeMounts:
                     description: Pod volumes to mount into the container's filesystem.
@@ -1525,9 +1606,18 @@ spec:
                           description: Path within the volume from which the container's
                             volume should be mounted. Defaults to "" (volume's root).
                           type: string
+                        subPathExpr:
+                          description: Expanded path within the volume from which
+                            the container's volume should be mounted. Behaves similarly
+                            to SubPath but environment variable references $(VAR_NAME)
+                            are expanded using the container's environment. Defaults
+                            to "" (volume's root). SubPathExpr and SubPath are mutually
+                            exclusive. This field is alpha in 1.14.
+                          type: string
                       required:
                       - name
                       - mountPath
+                      type: object
                     type: array
                   workingDir:
                     description: Container's working directory. If not specified,
@@ -1536,6 +1626,7 @@ spec:
                     type: string
                 required:
                 - name
+                type: object
               type: array
             enableAdminAPI:
               description: 'Enable access to prometheus web admin API. Defaults to
@@ -1574,6 +1665,7 @@ spec:
                   name:
                     description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                     type: string
+                type: object
               type: array
             listenLocal:
               description: ListenLocal makes the Prometheus server listen on loopback,
@@ -1667,6 +1759,7 @@ spec:
                             type: string
                         required:
                         - name
+                        type: object
                       type: array
                     result:
                       description: Status is a return value for calls that don't return
@@ -1719,6 +1812,7 @@ spec:
                                       the cause of the error. If this value is empty
                                       there is no information available.
                                     type: string
+                                type: object
                               type: array
                             group:
                               description: The group attribute of the resource associated
@@ -1748,6 +1842,7 @@ spec:
                                 single resource which can be described). More info:
                                 http://kubernetes.io/docs/user-guide/identifiers#uids'
                               type: string
+                          type: object
                         kind:
                           description: 'Kind is a string value representing the REST
                             resource this object represents. Servers may infer this
@@ -1789,6 +1884,7 @@ spec:
                               description: selfLink is a URL representing this object.
                                 Populated by the system. Read-only.
                               type: string
+                          type: object
                         reason:
                           description: A machine-readable description of why this
                             operation is in the "Failure" status. If this value is
@@ -1799,14 +1895,54 @@ spec:
                           description: 'Status of the operation. One of: "Success"
                             or "Failure". More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status'
                           type: string
+                      type: object
                   required:
                   - pending
+                  type: object
                 labels:
                   description: 'Map of string keys and values that can be used to
                     organize and categorize (scope and select) objects. May match
                     selectors of replication controllers and services. More info:
                     http://kubernetes.io/docs/user-guide/labels'
                   type: object
+                managedFields:
+                  description: |-
+                    ManagedFields maps workflow-id and version to the set of fields that are managed by that workflow. This is mostly for internal housekeeping, and users typically shouldn't need to set or understand this field. A workflow can be the user's name, a controller's name, or the name of a specific apply path like "ci-cd". The set of fields is always in the version that the workflow used when modifying the object.
+
+                    This field is alpha and can be changed or removed without notice.
+                  items:
+                    description: ManagedFieldsEntry is a workflow-id, a FieldSet and
+                      the group version of the resource that the fieldset applies
+                      to.
+                    properties:
+                      apiVersion:
+                        description: APIVersion defines the version of this resource
+                          that this field set applies to. The format is "group/version"
+                          just like the top-level APIVersion field. It is necessary
+                          to track the version of a field set because it cannot be
+                          automatically converted.
+                        type: string
+                      fields:
+                        description: 'Fields stores a set of fields in a data structure
+                          like a Trie. To understand how this is used, see: https://github.com/kubernetes-sigs/structured-merge-diff'
+                        type: object
+                      manager:
+                        description: Manager is an identifier of the workflow managing
+                          these fields.
+                        type: string
+                      operation:
+                        description: Operation is the type of operation which lead
+                          to this ManagedFieldsEntry being created. The only valid
+                          values for this field are 'Apply' and 'Update'.
+                        type: string
+                      time:
+                        description: Time is a wrapper around time.Time which supports
+                          correct marshaling to YAML and JSON.  Wrappers are provided
+                          for many of the factory methods that the time package offers.
+                        format: date-time
+                        type: string
+                    type: object
+                  type: array
                 name:
                   description: 'Name must be unique within a namespace. Is required
                     when creating resources, although some resources may allow a client
@@ -1860,6 +1996,7 @@ spec:
                     - kind
                     - name
                     - uid
+                    type: object
                   type: array
                 resourceVersion:
                   description: |-
@@ -1877,8 +2014,14 @@ spec:
 
                     Populated by the system. Read-only. More info: http://kubernetes.io/docs/user-guide/identifiers#uids
                   type: string
+              type: object
             priorityClassName:
               description: Priority class assigned to the Pods
+              type: string
+            prometheusExternalLabelName:
+              description: Name of Prometheus external label used to denote Prometheus
+                instance name. Defaults to the value of `prometheus`. External label
+                will _not_ be added when value is set to empty string (`""`).
               type: string
             query:
               description: QuerySpec defines the query command line flags when starting
@@ -1892,9 +2035,17 @@ spec:
                   description: Number of concurrent queries that can be run at once.
                   format: int32
                   type: integer
+                maxSamples:
+                  description: Maximum number of samples a single query can load into
+                    memory. Note that queries will fail if they would load more samples
+                    than this into memory, so this also limits the number of samples
+                    a query can return.
+                  format: int32
+                  type: integer
                 timeout:
                   description: Maximum time a query may take before being aborted.
                   type: string
+              type: object
             remoteRead:
               description: If specified, the remote_read spec. This is an experimental
                 feature, it may change in any upcoming release in a breaking way.
@@ -1922,6 +2073,7 @@ spec:
                             type: boolean
                         required:
                         - key
+                        type: object
                       username:
                         description: SecretKeySelector selects a key of a Secret.
                         properties:
@@ -1938,6 +2090,8 @@ spec:
                             type: boolean
                         required:
                         - key
+                        type: object
+                    type: object
                   bearerToken:
                     description: bearer token for remote read.
                     type: string
@@ -1976,11 +2130,13 @@ spec:
                       serverName:
                         description: Used to verify the hostname for the targets.
                         type: string
+                    type: object
                   url:
                     description: The URL of the endpoint to send samples to.
                     type: string
                 required:
                 - url
+                type: object
               type: array
             remoteWrite:
               description: If specified, the remote_write spec. This is an experimental
@@ -2009,6 +2165,7 @@ spec:
                             type: boolean
                         required:
                         - key
+                        type: object
                       username:
                         description: SecretKeySelector selects a key of a Secret.
                         properties:
@@ -2025,6 +2182,8 @@ spec:
                             type: boolean
                         required:
                         - key
+                        type: object
+                    type: object
                   bearerToken:
                     description: File to read bearer token for remote write.
                     type: string
@@ -2075,6 +2234,7 @@ spec:
                           amount of concurrency.
                         format: int32
                         type: integer
+                    type: object
                   remoteTimeout:
                     description: Timeout for requests to the remote write endpoint.
                     type: string
@@ -2096,6 +2256,7 @@ spec:
                       serverName:
                         description: Used to verify the hostname for the targets.
                         type: string
+                    type: object
                   url:
                     description: The URL of the endpoint to send samples to.
                     type: string
@@ -2142,13 +2303,16 @@ spec:
                             in a replace action. It is mandatory for replace actions.
                             Regex capture groups are available.
                           type: string
+                      type: object
                     type: array
                 required:
                 - url
+                type: object
               type: array
             replicaExternalLabelName:
               description: Name of Prometheus external label used to denote replica
-                name. Defaults to the value of `prometheus_replica`.
+                name. Defaults to the value of `prometheus_replica`. External label
+                will _not_ be added when value is set to empty string (`""`).
               type: string
             replicas:
               description: Number of instances to deploy for a Prometheus deployment.
@@ -2167,6 +2331,7 @@ spec:
                     to Limits if that is explicitly specified, otherwise to an implementation-defined
                     value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                   type: object
+              type: object
             retention:
               description: Time duration Prometheus shall retain data for. Default
                 is '24h', and must match the regular expression `[0-9]+(ms|s|m|h|d|w|y)`
@@ -2213,6 +2378,7 @@ spec:
                     required:
                     - key
                     - operator
+                    type: object
                   type: array
                 matchLabels:
                   description: matchLabels is a map of {key,value} pairs. A single
@@ -2221,6 +2387,7 @@ spec:
                     "In", and the values array contains only "value". The requirements
                     are ANDed.
                   type: object
+              type: object
             ruleSelector:
               description: A label selector is a label query over a set of resources.
                 The result of matchLabels and matchExpressions are ANDed. An empty
@@ -2255,6 +2422,7 @@ spec:
                     required:
                     - key
                     - operator
+                    type: object
                   type: array
                 matchLabels:
                   description: matchLabels is a map of {key,value} pairs. A single
@@ -2263,6 +2431,7 @@ spec:
                     "In", and the values array contains only "value". The requirements
                     are ANDed.
                   type: object
+              type: object
             rules:
               description: /--rules.*/ command-line arguments
               properties:
@@ -2282,6 +2451,8 @@ spec:
                       description: Minimum amount of time to wait before resending
                         an alert to Alertmanager.
                       type: string
+                  type: object
+              type: object
             scrapeInterval:
               description: Interval between consecutive scrapes.
               type: string
@@ -2351,6 +2522,7 @@ spec:
                       description: User is a SELinux user label that applies to the
                         container.
                       type: string
+                  type: object
                 supplementalGroups:
                   description: A list of groups applied to the first process run in
                     each container, in addition to the container's primary GID.  If
@@ -2375,7 +2547,9 @@ spec:
                     required:
                     - name
                     - value
+                    type: object
                   type: array
+              type: object
             serviceAccountName:
               description: ServiceAccountName is the name of the ServiceAccount to
                 use to run the Prometheus Pods.
@@ -2414,6 +2588,7 @@ spec:
                     required:
                     - key
                     - operator
+                    type: object
                   type: array
                 matchLabels:
                   description: matchLabels is a map of {key,value} pairs. A single
@@ -2422,6 +2597,7 @@ spec:
                     "In", and the values array contains only "value". The requirements
                     are ANDed.
                   type: object
+              type: object
             serviceMonitorSelector:
               description: A label selector is a label query over a set of resources.
                 The result of matchLabels and matchExpressions are ANDed. An empty
@@ -2456,6 +2632,7 @@ spec:
                     required:
                     - key
                     - operator
+                    type: object
                   type: array
                 matchLabels:
                   description: matchLabels is a map of {key,value} pairs. A single
@@ -2464,6 +2641,7 @@ spec:
                     "In", and the values array contains only "value". The requirements
                     are ANDed.
                   type: object
+              type: object
             sha:
               description: SHA of Prometheus container image to be deployed. Defaults
                 to the value of `version`. Similar to a tag, but the SHA explicitly
@@ -2486,6 +2664,7 @@ spec:
                         Must be an empty string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                       type: string
                     sizeLimit: {}
+                  type: object
                 volumeClaimTemplate:
                   description: PersistentVolumeClaim is a user's request for and claim
                     to a persistent volume
@@ -2583,6 +2762,7 @@ spec:
                                     type: string
                                 required:
                                 - name
+                                type: object
                               type: array
                             result:
                               description: Status is a return value for calls that
@@ -2638,6 +2818,7 @@ spec:
                                               of the cause of the error. If this value
                                               is empty there is no information available.
                                             type: string
+                                        type: object
                                       type: array
                                     group:
                                       description: The group attribute of the resource
@@ -2668,6 +2849,7 @@ spec:
                                         is a single resource which can be described).
                                         More info: http://kubernetes.io/docs/user-guide/identifiers#uids'
                                       type: string
+                                  type: object
                                 kind:
                                   description: 'Kind is a string value representing
                                     the REST resource this object represents. Servers
@@ -2714,6 +2896,7 @@ spec:
                                       description: selfLink is a URL representing
                                         this object. Populated by the system. Read-only.
                                       type: string
+                                  type: object
                                 reason:
                                   description: A machine-readable description of why
                                     this operation is in the "Failure" status. If
@@ -2725,14 +2908,57 @@ spec:
                                   description: 'Status of the operation. One of: "Success"
                                     or "Failure". More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status'
                                   type: string
+                              type: object
                           required:
                           - pending
+                          type: object
                         labels:
                           description: 'Map of string keys and values that can be
                             used to organize and categorize (scope and select) objects.
                             May match selectors of replication controllers and services.
                             More info: http://kubernetes.io/docs/user-guide/labels'
                           type: object
+                        managedFields:
+                          description: |-
+                            ManagedFields maps workflow-id and version to the set of fields that are managed by that workflow. This is mostly for internal housekeeping, and users typically shouldn't need to set or understand this field. A workflow can be the user's name, a controller's name, or the name of a specific apply path like "ci-cd". The set of fields is always in the version that the workflow used when modifying the object.
+
+                            This field is alpha and can be changed or removed without notice.
+                          items:
+                            description: ManagedFieldsEntry is a workflow-id, a FieldSet
+                              and the group version of the resource that the fieldset
+                              applies to.
+                            properties:
+                              apiVersion:
+                                description: APIVersion defines the version of this
+                                  resource that this field set applies to. The format
+                                  is "group/version" just like the top-level APIVersion
+                                  field. It is necessary to track the version of a
+                                  field set because it cannot be automatically converted.
+                                type: string
+                              fields:
+                                description: 'Fields stores a set of fields in a data
+                                  structure like a Trie. To understand how this is
+                                  used, see: https://github.com/kubernetes-sigs/structured-merge-diff'
+                                type: object
+                              manager:
+                                description: Manager is an identifier of the workflow
+                                  managing these fields.
+                                type: string
+                              operation:
+                                description: Operation is the type of operation which
+                                  lead to this ManagedFieldsEntry being created. The
+                                  only valid values for this field are 'Apply' and
+                                  'Update'.
+                                type: string
+                              time:
+                                description: Time is a wrapper around time.Time which
+                                  supports correct marshaling to YAML and JSON.  Wrappers
+                                  are provided for many of the factory methods that
+                                  the time package offers.
+                                format: date-time
+                                type: string
+                            type: object
+                          type: array
                         name:
                           description: 'Name must be unique within a namespace. Is
                             required when creating resources, although some resources
@@ -2789,6 +3015,7 @@ spec:
                             - kind
                             - name
                             - uid
+                            type: object
                           type: array
                         resourceVersion:
                           description: |-
@@ -2806,6 +3033,7 @@ spec:
 
                             Populated by the system. Read-only. More info: http://kubernetes.io/docs/user-guide/identifiers#uids
                           type: string
+                      type: object
                     spec:
                       description: PersistentVolumeClaimSpec describes the common
                         attributes of storage devices and allows a Source for provider-specific
@@ -2837,6 +3065,7 @@ spec:
                           required:
                           - kind
                           - name
+                          type: object
                         resources:
                           description: ResourceRequirements describes the compute
                             resource requirements.
@@ -2852,6 +3081,7 @@ spec:
                                 explicitly specified, otherwise to an implementation-defined
                                 value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                               type: object
+                          type: object
                         selector:
                           description: A label selector is a label query over a set
                             of resources. The result of matchLabels and matchExpressions
@@ -2888,6 +3118,7 @@ spec:
                                 required:
                                 - key
                                 - operator
+                                type: object
                               type: array
                             matchLabels:
                               description: matchLabels is a map of {key,value} pairs.
@@ -2896,6 +3127,7 @@ spec:
                                 is "key", the operator is "In", and the values array
                                 contains only "value". The requirements are ANDed.
                               type: object
+                          type: object
                         storageClassName:
                           description: 'Name of the StorageClass required by the claim.
                             More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
@@ -2909,6 +3141,7 @@ spec:
                           description: VolumeName is the binding reference to the
                             PersistentVolume backing this claim.
                           type: string
+                      type: object
                     status:
                       description: PersistentVolumeClaimStatus is the current status
                         of a persistent volume claim.
@@ -2963,10 +3196,14 @@ spec:
                             required:
                             - type
                             - status
+                            type: object
                           type: array
                         phase:
                           description: Phase represents the current phase of PersistentVolumeClaim.
                           type: string
+                      type: object
+                  type: object
+              type: object
             tag:
               description: Tag of Prometheus container image to be deployed. Defaults
                 to the value of `version`. Version is ignored if Tag is set.
@@ -3007,6 +3244,8 @@ spec:
                           type: boolean
                       required:
                       - key
+                      type: object
+                  type: object
                 grpcAdvertiseAddress:
                   description: Explicit (external) host:port address to advertise
                     for gRPC StoreAPI in gossip cluster. If empty, 'grpc-address'
@@ -3034,6 +3273,7 @@ spec:
                       type: boolean
                   required:
                   - key
+                  type: object
                 peers:
                   description: Peers is a DNS name for Thanos to discover peers through.
                   type: string
@@ -3051,6 +3291,7 @@ spec:
                         it defaults to Limits if that is explicitly specified, otherwise
                         to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                       type: object
+                  type: object
                 s3:
                   description: 'Deprecated: ThanosS3Spec should be configured with
                     an ObjectStorageConfig secret starting with Thanos v0.2.0. ThanosS3Spec
@@ -3072,6 +3313,7 @@ spec:
                           type: boolean
                       required:
                       - key
+                      type: object
                     bucket:
                       description: S3-Compatible API bucket name for stored blocks.
                       type: string
@@ -3101,10 +3343,12 @@ spec:
                           type: boolean
                       required:
                       - key
+                      type: object
                     signatureVersion2:
                       description: Whether to use S3 Signature Version 2; otherwise
                         Signature Version 4 will be used.
                       type: boolean
+                  type: object
                 sha:
                   description: SHA of Thanos container image to be deployed. Defaults
                     to the value of `version`. Similar to a tag, but the SHA explicitly
@@ -3119,6 +3363,7 @@ spec:
                 version:
                   description: Version describes the version of Thanos to use.
                   type: string
+              type: object
             tolerations:
               description: If specified, the pod's tolerations.
               items:
@@ -3157,10 +3402,12 @@ spec:
                       If the operator is Exists, the value should be empty, otherwise
                       just a regular string.
                     type: string
+                type: object
               type: array
             version:
               description: Version of Prometheus to be deployed.
               type: string
+          type: object
         status:
           description: 'PrometheusStatus is the most recent observed status of the
             Prometheus cluster. Read-only. Not included when requesting from the apiserver,
@@ -3196,4 +3443,6 @@ spec:
           - updatedReplicas
           - availableReplicas
           - unavailableReplicas
+          type: object
+      type: object
   version: v1

--- a/manifests/0prometheus-operator-0prometheusruleCustomResourceDefinition.yaml
+++ b/manifests/0prometheus-operator-0prometheusruleCustomResourceDefinition.yaml
@@ -96,6 +96,7 @@ spec:
                         type: string
                     required:
                     - name
+                    type: object
                   type: array
                 result:
                   description: Status is a return value for calls that don't return
@@ -148,6 +149,7 @@ spec:
                                   cause of the error. If this value is empty there
                                   is no information available.
                                 type: string
+                            type: object
                           type: array
                         group:
                           description: The group attribute of the resource associated
@@ -175,6 +177,7 @@ spec:
                           description: 'UID of the resource. (when there is a single
                             resource which can be described). More info: http://kubernetes.io/docs/user-guide/identifiers#uids'
                           type: string
+                      type: object
                     kind:
                       description: 'Kind is a string value representing the REST resource
                         this object represents. Servers may infer this from the endpoint
@@ -215,6 +218,7 @@ spec:
                           description: selfLink is a URL representing this object.
                             Populated by the system. Read-only.
                           type: string
+                      type: object
                     reason:
                       description: A machine-readable description of why this operation
                         is in the "Failure" status. If this value is empty there is
@@ -225,13 +229,52 @@ spec:
                       description: 'Status of the operation. One of: "Success" or
                         "Failure". More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status'
                       type: string
+                  type: object
               required:
               - pending
+              type: object
             labels:
               description: 'Map of string keys and values that can be used to organize
                 and categorize (scope and select) objects. May match selectors of
                 replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels'
               type: object
+            managedFields:
+              description: |-
+                ManagedFields maps workflow-id and version to the set of fields that are managed by that workflow. This is mostly for internal housekeeping, and users typically shouldn't need to set or understand this field. A workflow can be the user's name, a controller's name, or the name of a specific apply path like "ci-cd". The set of fields is always in the version that the workflow used when modifying the object.
+
+                This field is alpha and can be changed or removed without notice.
+              items:
+                description: ManagedFieldsEntry is a workflow-id, a FieldSet and the
+                  group version of the resource that the fieldset applies to.
+                properties:
+                  apiVersion:
+                    description: APIVersion defines the version of this resource that
+                      this field set applies to. The format is "group/version" just
+                      like the top-level APIVersion field. It is necessary to track
+                      the version of a field set because it cannot be automatically
+                      converted.
+                    type: string
+                  fields:
+                    description: 'Fields stores a set of fields in a data structure
+                      like a Trie. To understand how this is used, see: https://github.com/kubernetes-sigs/structured-merge-diff'
+                    type: object
+                  manager:
+                    description: Manager is an identifier of the workflow managing
+                      these fields.
+                    type: string
+                  operation:
+                    description: Operation is the type of operation which lead to
+                      this ManagedFieldsEntry being created. The only valid values
+                      for this field are 'Apply' and 'Update'.
+                    type: string
+                  time:
+                    description: Time is a wrapper around time.Time which supports
+                      correct marshaling to YAML and JSON.  Wrappers are provided
+                      for many of the factory methods that the time package offers.
+                    format: date-time
+                    type: string
+                type: object
+              type: array
             name:
               description: 'Name must be unique within a namespace. Is required when
                 creating resources, although some resources may allow a client to
@@ -284,6 +327,7 @@ spec:
                 - kind
                 - name
                 - uid
+                type: object
               type: array
             resourceVersion:
               description: |-
@@ -301,6 +345,7 @@ spec:
 
                 Populated by the system. Read-only. More info: http://kubernetes.io/docs/user-guide/identifiers#uids
               type: string
+          type: object
         spec:
           description: PrometheusRuleSpec contains specification parameters for a
             Rule.
@@ -335,9 +380,13 @@ spec:
                           type: string
                       required:
                       - expr
+                      type: object
                     type: array
                 required:
                 - name
                 - rules
+                type: object
               type: array
+          type: object
+      type: object
   version: v1

--- a/manifests/0prometheus-operator-0servicemonitorCustomResourceDefinition.yaml
+++ b/manifests/0prometheus-operator-0servicemonitorCustomResourceDefinition.yaml
@@ -52,6 +52,7 @@ spec:
                             type: boolean
                         required:
                         - key
+                        type: object
                       username:
                         description: SecretKeySelector selects a key of a Secret.
                         properties:
@@ -68,6 +69,8 @@ spec:
                             type: boolean
                         required:
                         - key
+                        type: object
+                    type: object
                   bearerTokenFile:
                     description: File to read bearer token for scraping targets.
                     type: string
@@ -121,6 +124,7 @@ spec:
                             in a replace action. It is mandatory for replace actions.
                             Regex capture groups are available.
                           type: string
+                      type: object
                     type: array
                   params:
                     description: Optional HTTP URL parameters
@@ -180,6 +184,7 @@ spec:
                             in a replace action. It is mandatory for replace actions.
                             Regex capture groups are available.
                           type: string
+                      type: object
                     type: array
                   scheme:
                     description: HTTP scheme to use for scraping.
@@ -209,6 +214,8 @@ spec:
                       serverName:
                         description: Used to verify the hostname for the targets.
                         type: string
+                    type: object
+                type: object
               type: array
             jobLabel:
               description: The label to use to retrieve the job name from.
@@ -226,6 +233,7 @@ spec:
                   items:
                     type: string
                   type: array
+              type: object
             podTargetLabels:
               description: PodTargetLabels transfers labels on the Kubernetes Pod
                 onto the target.
@@ -271,6 +279,7 @@ spec:
                     required:
                     - key
                     - operator
+                    type: object
                   type: array
                 matchLabels:
                   description: matchLabels is a map of {key,value} pairs. A single
@@ -279,6 +288,7 @@ spec:
                     "In", and the values array contains only "value". The requirements
                     are ANDed.
                   type: object
+              type: object
             targetLabels:
               description: TargetLabels transfers labels on the Kubernetes Service
                 onto the target.
@@ -288,4 +298,6 @@ spec:
           required:
           - endpoints
           - selector
+          type: object
+      type: object
   version: v1

--- a/manifests/0prometheus-operator-clusterRole.yaml
+++ b/manifests/0prometheus-operator-clusterRole.yaml
@@ -1,6 +1,10 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  labels:
+    apps.kubernetes.io/component: controller
+    apps.kubernetes.io/name: prometheus-operator
+    apps.kubernetes.io/version: v0.30.0
   name: prometheus-operator
 rules:
 - apiGroups:

--- a/manifests/0prometheus-operator-clusterRoleBinding.yaml
+++ b/manifests/0prometheus-operator-clusterRoleBinding.yaml
@@ -1,6 +1,10 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
+  labels:
+    apps.kubernetes.io/component: controller
+    apps.kubernetes.io/name: prometheus-operator
+    apps.kubernetes.io/version: v0.30.0
   name: prometheus-operator
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/manifests/0prometheus-operator-deployment.yaml
+++ b/manifests/0prometheus-operator-deployment.yaml
@@ -2,26 +2,31 @@ apiVersion: apps/v1beta2
 kind: Deployment
 metadata:
   labels:
-    k8s-app: prometheus-operator
+    apps.kubernetes.io/component: controller
+    apps.kubernetes.io/name: prometheus-operator
+    apps.kubernetes.io/version: v0.30.0
   name: prometheus-operator
   namespace: monitoring
 spec:
   replicas: 1
   selector:
     matchLabels:
-      k8s-app: prometheus-operator
+      apps.kubernetes.io/component: controller
+      apps.kubernetes.io/name: prometheus-operator
   template:
     metadata:
       labels:
-        k8s-app: prometheus-operator
+        apps.kubernetes.io/component: controller
+        apps.kubernetes.io/name: prometheus-operator
+        apps.kubernetes.io/version: v0.30.0
     spec:
       containers:
       - args:
         - --kubelet-service=kube-system/kubelet
         - --logtostderr=true
         - --config-reloader-image=quay.io/coreos/configmap-reload:v0.0.1
-        - --prometheus-config-reloader=quay.io/coreos/prometheus-config-reloader:v0.29.0
-        image: quay.io/coreos/prometheus-operator:v0.29.0
+        - --prometheus-config-reloader=quay.io/coreos/prometheus-config-reloader:v0.30.0
+        image: quay.io/coreos/prometheus-operator:v0.30.0
         name: prometheus-operator
         ports:
         - containerPort: 8080

--- a/manifests/0prometheus-operator-service.yaml
+++ b/manifests/0prometheus-operator-service.yaml
@@ -2,7 +2,9 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    k8s-app: prometheus-operator
+    apps.kubernetes.io/component: controller
+    apps.kubernetes.io/name: prometheus-operator
+    apps.kubernetes.io/version: v0.30.0
   name: prometheus-operator
   namespace: monitoring
 spec:
@@ -12,4 +14,5 @@ spec:
     port: 8080
     targetPort: http
   selector:
-    k8s-app: prometheus-operator
+    apps.kubernetes.io/component: controller
+    apps.kubernetes.io/name: prometheus-operator

--- a/manifests/0prometheus-operator-serviceAccount.yaml
+++ b/manifests/0prometheus-operator-serviceAccount.yaml
@@ -1,5 +1,9 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+  labels:
+    apps.kubernetes.io/component: controller
+    apps.kubernetes.io/name: prometheus-operator
+    apps.kubernetes.io/version: v0.30.0
   name: prometheus-operator
   namespace: monitoring

--- a/manifests/0prometheus-operator-serviceMonitor.yaml
+++ b/manifests/0prometheus-operator-serviceMonitor.yaml
@@ -2,7 +2,9 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   labels:
-    k8s-app: prometheus-operator
+    apps.kubernetes.io/component: controller
+    apps.kubernetes.io/name: prometheus-operator
+    apps.kubernetes.io/version: v0.30.0
   name: prometheus-operator
   namespace: monitoring
 spec:
@@ -11,4 +13,6 @@ spec:
     port: http
   selector:
     matchLabels:
-      k8s-app: prometheus-operator
+      apps.kubernetes.io/component: controller
+      apps.kubernetes.io/name: prometheus-operator
+      apps.kubernetes.io/version: v0.30.0

--- a/manifests/prometheus-rules.yaml
+++ b/manifests/prometheus-rules.yaml
@@ -14,39 +14,25 @@ spec:
         sum(rate(container_cpu_usage_seconds_total{job="kubelet", image!="", container_name!=""}[5m])) by (namespace)
       record: namespace:container_cpu_usage_seconds_total:sum_rate
     - expr: |
+        sum(container_memory_usage_bytes{job="kubelet", image!="", container_name!=""}) by (namespace)
+      record: namespace:container_memory_usage_bytes:sum
+    - expr: |
         sum by (namespace, pod_name, container_name) (
           rate(container_cpu_usage_seconds_total{job="kubelet", image!="", container_name!=""}[5m])
         )
       record: namespace_pod_name_container_name:container_cpu_usage_seconds_total:sum_rate
     - expr: |
-        sum(container_memory_usage_bytes{job="kubelet", image!="", container_name!=""}) by (namespace)
-      record: namespace:container_memory_usage_bytes:sum
-    - expr: |
-        sum by (namespace, label_name) (
-           sum(rate(container_cpu_usage_seconds_total{job="kubelet", image!="", container_name!=""}[5m])) by (namespace, pod_name)
-         * on (namespace, pod_name) group_left(label_name)
-           label_replace(kube_pod_labels{job="kube-state-metrics"}, "pod_name", "$1", "pod", "(.*)")
-        )
-      record: namespace_name:container_cpu_usage_seconds_total:sum_rate
-    - expr: |
-        sum by (namespace, label_name) (
-          sum(container_memory_usage_bytes{job="kubelet",image!="", container_name!=""}) by (pod_name, namespace)
-        * on (namespace, pod_name) group_left(label_name)
-          label_replace(kube_pod_labels{job="kube-state-metrics"}, "pod_name", "$1", "pod", "(.*)")
-        )
-      record: namespace_name:container_memory_usage_bytes:sum
-    - expr: |
-        sum by (namespace, label_name) (
-          sum(kube_pod_container_resource_requests_memory_bytes{job="kube-state-metrics"} * on (endpoint, instance, job, namespace, pod, service) group_left(phase) (kube_pod_status_phase{phase=~"^(Pending|Running)$"} == 1)) by (namespace, pod)
-        * on (namespace, pod) group_left(label_name)
-          label_replace(kube_pod_labels{job="kube-state-metrics"}, "pod_name", "$1", "pod", "(.*)")
+        sum by(namespace) (
+            kube_pod_container_resource_requests_memory_bytes{job="kube-state-metrics"}
+          * on (endpoint, instance, job, namespace, pod, service)
+            group_left(phase) (kube_pod_status_phase{phase=~"^(Pending|Running)$"} == 1)
         )
       record: namespace_name:kube_pod_container_resource_requests_memory_bytes:sum
     - expr: |
-        sum by (namespace, label_name) (
-          sum(kube_pod_container_resource_requests_cpu_cores{job="kube-state-metrics"} * on (endpoint, instance, job, namespace, pod, service) group_left(phase) (kube_pod_status_phase{phase=~"^(Pending|Running)$"} == 1)) by (namespace, pod)
-        * on (namespace, pod) group_left(label_name)
-          label_replace(kube_pod_labels{job="kube-state-metrics"}, "pod_name", "$1", "pod", "(.*)")
+        sum by (namespace) (
+            kube_pod_container_resource_requests_cpu_cores{job="kube-state-metrics"}
+          * on (endpoint, instance, job, namespace, pod, service)
+            group_left(phase) (kube_pod_status_phase{phase=~"^(Pending|Running)$"} == 1)
         )
       record: namespace_name:kube_pod_container_resource_requests_cpu_cores:sum
     - expr: |


### PR DESCRIPTION
Addresses [#105] in the `master` branch. (An earlier PR, [#106], addresses the same issue in the `release-0.1` branch.) And, again, please let me know if the `kube-prometheus` version in `/jsonnetfile.lock.json` should be bumped in one additional commit.

[#105]: https://github.com/coreos/kube-prometheus/issues/105
[#106]: https://github.com/coreos/kube-prometheus/pull/106