### PR TITLE
Add commented imports for most common patches to example.jsonnet

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,14 @@ Here's [example.jsonnet](example.jsonnet):
 [embedmd]:# (example.jsonnet)
 ```jsonnet
 local kp =
-  (import 'kube-prometheus/kube-prometheus.libsonnet') + {
+  (import 'kube-prometheus/kube-prometheus.libsonnet') +
+  // Uncomment the following imports to enable its patches
+  // (import 'kube-prometheus/kube-prometheus-anti-affinity.libsonnet') +
+  // (import 'kube-prometheus/kube-prometheus-managed-cluster.libsonnet') +
+  // (import 'kube-prometheus/kube-prometheus-node-ports.libsonnet') +
+  // (import 'kube-prometheus/kube-prometheus-static-etcd.libsonnet') +
+  // (import 'kube-prometheus/kube-prometheus-thanos.libsonnet') +
+  {
     _config+:: {
       namespace: 'monitoring',
     },

--- a/docs/developing-prometheus-rules-and-grafana-dashboards.md
+++ b/docs/developing-prometheus-rules-and-grafana-dashboards.md
@@ -11,7 +11,14 @@ As a basis, all examples in this guide are based on the base example of the kube
 [embedmd]:# (../example.jsonnet)
 ```jsonnet
 local kp =
-  (import 'kube-prometheus/kube-prometheus.libsonnet') + {
+  (import 'kube-prometheus/kube-prometheus.libsonnet') +
+  // Uncomment the following imports to enable its patches
+  // (import 'kube-prometheus/kube-prometheus-anti-affinity.libsonnet') +
+  // (import 'kube-prometheus/kube-prometheus-managed-cluster.libsonnet') +
+  // (import 'kube-prometheus/kube-prometheus-node-ports.libsonnet') +
+  // (import 'kube-prometheus/kube-prometheus-static-etcd.libsonnet') +
+  // (import 'kube-prometheus/kube-prometheus-thanos.libsonnet') +
+  {
     _config+:: {
       namespace: 'monitoring',
     },

--- a/example.jsonnet
+++ b/example.jsonnet
@@ -1,5 +1,12 @@
 local kp =
-  (import 'kube-prometheus/kube-prometheus.libsonnet') + {
+  (import 'kube-prometheus/kube-prometheus.libsonnet') +
+  // Uncomment the following imports to enable its patches
+  // (import 'kube-prometheus/kube-prometheus-anti-affinity.libsonnet') +
+  // (import 'kube-prometheus/kube-prometheus-managed-cluster.libsonnet') +
+  // (import 'kube-prometheus/kube-prometheus-node-ports.libsonnet') +
+  // (import 'kube-prometheus/kube-prometheus-static-etcd.libsonnet') +
+  // (import 'kube-prometheus/kube-prometheus-thanos.libsonnet') +
+  {
     _config+:: {
       namespace: 'monitoring',
     },


### PR DESCRIPTION
I think we can improve the entry point for new people, by adding the most common imports to `example.jsonnet` so that those only need to be uncommented. 

/cc @brancz @paulfantom @squat @s-urbaniak 