### PR TITLE
Add mixin to strip cpu/memory limits (issue #72)

### DIFF
--- a/jsonnet/kube-prometheus/kube-prometheus-strip-limits.libsonnet
+++ b/jsonnet/kube-prometheus/kube-prometheus-strip-limits.libsonnet
@@ -7,10 +7,10 @@
         template+: {
           spec+: {
             local stripLimits(c) =
-                if std.count([
-                    'node-exporter',
-                    'kube-rbac-proxy'
-                ], c.name) > 0
+                if std.setMember(c.name, [
+                  'kube-rbac-proxy',
+                  'node-exporter',
+                ])
                 then c + {resources+: {limits: {}}}
                 else c,
             containers: std.map(stripLimits, super.containers),
@@ -40,11 +40,11 @@
         template+: {
           spec+: {
             local stripLimits(c) =
-                if std.count([
-                    'kube-rbac-proxy-main',
-                    'kube-rbac-proxy-self',
-                    'addon-resizer'
-                ], c.name) > 0
+                if std.setMember(c.name, [
+                  'addon-resizer',
+                  'kube-rbac-proxy-main',
+                  'kube-rbac-proxy-self',
+                ])
                 then c + {resources+: {limits: {}}}
                 else c,
             containers: std.map(stripLimits, super.containers),

--- a/jsonnet/kube-prometheus/kube-prometheus-strip-limits.libsonnet
+++ b/jsonnet/kube-prometheus/kube-prometheus-strip-limits.libsonnet
@@ -3,13 +3,13 @@
 {
   _config+:: {
     resources+:: {
-      'addon-resizer': {
+      'addon-resizer'+: {
         limits: {},
       },
-      'kube-rbac-proxy': {
+      'kube-rbac-proxy'+: {
         limits: {},
       },
-      'node-exporter': {
+      'node-exporter'+: {
         limits: {},
       },
     },

--- a/jsonnet/kube-prometheus/kube-prometheus-strip-limits.libsonnet
+++ b/jsonnet/kube-prometheus/kube-prometheus-strip-limits.libsonnet
@@ -1,21 +1,16 @@
 // Strips spec.containers[].limits for certain containers
 // https://github.com/coreos/kube-prometheus/issues/72
 {
-  nodeExporter+: {
-    daemonset+: {
-      spec+: {
-        template+: {
-          spec+: {
-            local stripLimits(c) =
-                if std.setMember(c.name, [
-                  'kube-rbac-proxy',
-                  'node-exporter',
-                ])
-                then c + {resources+: {limits: {}}}
-                else c,
-            containers: std.map(stripLimits, super.containers),
-          },
-        },
+  _config+:: {
+    resources+:: {
+      'addon-resizer': {
+        limits: {},
+      },
+      'kube-rbac-proxy': {
+        limits: {},
+      },
+      'node-exporter': {
+        limits: {},
       },
     },
   },
@@ -29,25 +24,6 @@
                 then c + {args+: ['--config-reloader-cpu=0']}
                 else c,
             containers: std.map(addArgs, super.containers),
-          },
-        },
-      },
-    },
-  },
-  kubeStateMetrics+: {
-    deployment+: {
-      spec+: {
-        template+: {
-          spec+: {
-            local stripLimits(c) =
-                if std.setMember(c.name, [
-                  'addon-resizer',
-                  'kube-rbac-proxy-main',
-                  'kube-rbac-proxy-self',
-                ])
-                then c + {resources+: {limits: {}}}
-                else c,
-            containers: std.map(stripLimits, super.containers),
           },
         },
       },

--- a/jsonnet/kube-prometheus/kube-prometheus-strip-limits.libsonnet
+++ b/jsonnet/kube-prometheus/kube-prometheus-strip-limits.libsonnet
@@ -1,0 +1,56 @@
+// Strips spec.containers[].limits for certain containers
+// https://github.com/coreos/kube-prometheus/issues/72
+{
+  nodeExporter+: {
+    daemonset+: {
+      spec+: {
+        template+: {
+          spec+: {
+            local stripLimits(c) =
+                if std.count([
+                    'node-exporter',
+                    'kube-rbac-proxy'
+                ], c.name) > 0
+                then c + {resources+: {limits: {}}}
+                else c,
+            containers: std.map(stripLimits, super.containers),
+          },
+        },
+      },
+    },
+  },
+  prometheusOperator+: {
+    deployment+: {
+      spec+: {
+        template+: {
+          spec+: {
+            local addArgs(c) =
+                if c.name == 'prometheus-operator'
+                then c + {args+: ['--config-reloader-cpu=0']}
+                else c,
+            containers: std.map(addArgs, super.containers),
+          },
+        },
+      },
+    },
+  },
+  kubeStateMetrics+: {
+    deployment+: {
+      spec+: {
+        template+: {
+          spec+: {
+            local stripLimits(c) =
+                if std.count([
+                    'kube-rbac-proxy-main',
+                    'kube-rbac-proxy-self',
+                    'addon-resizer'
+                ], c.name) > 0
+                then c + {resources+: {limits: {}}}
+                else c,
+            containers: std.map(stripLimits, super.containers),
+          },
+        },
+      },
+    },
+  },
+}

--- a/jsonnet/kube-prometheus/kube-prometheus.libsonnet
+++ b/jsonnet/kube-prometheus/kube-prometheus.libsonnet
@@ -104,6 +104,20 @@ local configMapList = k3.core.v1.configMapList;
       CoreDNS: $._config.coreDNSSelector,
     },
 
+    resources+:: {
+      'addon-resizer': {
+        requests: { cpu: '10m', memory: '30Mi' },
+        limits: { cpu: '50m', memory: '30Mi' },
+      },
+      'kube-rbac-proxy': {
+        requests: { cpu: '10m', memory: '20Mi' },
+        limits: { cpu: '20m', memory: '40Mi' },
+      },
+      'node-exporter': {
+        requests: { cpu: '102m', memory: '180Mi' },
+        limits: { cpu: '250m', memory: '180Mi' },
+      },
+    },
     prometheus+:: {
       rules: $.prometheusRules + $.prometheusAlerts,
     },

--- a/jsonnet/kube-prometheus/kube-state-metrics/kube-state-metrics.libsonnet
+++ b/jsonnet/kube-prometheus/kube-state-metrics/kube-state-metrics.libsonnet
@@ -140,8 +140,8 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
           '--upstream=http://127.0.0.1:8081/',
         ]) +
         container.withPorts(containerPort.newNamed(8443, 'https-main',)) +
-        container.mixin.resources.withRequests({ cpu: '10m', memory: '20Mi' }) +
-        container.mixin.resources.withLimits({ cpu: '20m', memory: '40Mi' });
+        container.mixin.resources.withRequests($._config.resources['kube-rbac-proxy'].requests) +
+        container.mixin.resources.withLimits($._config.resources['kube-rbac-proxy'].limits);
 
       local proxySelfMetrics =
         container.new('kube-rbac-proxy-self', $._config.imageRepos.kubeRbacProxy + ':' + $._config.versions.kubeRbacProxy) +
@@ -152,8 +152,8 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
           '--upstream=http://127.0.0.1:8082/',
         ]) +
         container.withPorts(containerPort.newNamed(9443, 'https-self',)) +
-        container.mixin.resources.withRequests({ cpu: '10m', memory: '20Mi' }) +
-        container.mixin.resources.withLimits({ cpu: '20m', memory: '40Mi' });
+        container.mixin.resources.withRequests($._config.resources['kube-rbac-proxy'].requests) +
+        container.mixin.resources.withLimits($._config.resources['kube-rbac-proxy'].limits);
 
       local kubeStateMetrics =
         container.new('kube-state-metrics', $._config.imageRepos.kubeStateMetrics + ':' + $._config.versions.kubeStateMetrics) +
@@ -192,8 +192,8 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
             },
           },
         ]) +
-        container.mixin.resources.withRequests({ cpu: '10m', memory: '30Mi' }) +
-        container.mixin.resources.withLimits({ cpu: '50m', memory: '30Mi' });
+        container.mixin.resources.withRequests($._config.resources['addon-resizer'].requests) +
+        container.mixin.resources.withLimits($._config.resources['addon-resizer'].limits);
 
       local c = [proxyClusterMetrics, proxySelfMetrics, kubeStateMetrics, addonResizer];
 

--- a/jsonnet/kube-prometheus/node-exporter/node-exporter.libsonnet
+++ b/jsonnet/kube-prometheus/node-exporter/node-exporter.libsonnet
@@ -97,8 +97,8 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
           '--collector.filesystem.ignored-fs-types=^(autofs|binfmt_misc|cgroup|configfs|debugfs|devpts|devtmpfs|fusectl|hugetlbfs|mqueue|overlay|proc|procfs|pstore|rpc_pipefs|securityfs|sysfs|tracefs)$',
         ]) +
         container.withVolumeMounts([procVolumeMount, sysVolumeMount, rootVolumeMount]) +
-        container.mixin.resources.withRequests({ cpu: '102m', memory: '180Mi' }) +
-        container.mixin.resources.withLimits({ cpu: '250m', memory: '180Mi' });
+        container.mixin.resources.withRequests($._config.resources['node-exporter'].requests) +
+        container.mixin.resources.withLimits($._config.resources['node-exporter'].requests);
 
       local ip = containerEnv.fromFieldPath('IP', 'status.podIP');
       local proxy =


### PR DESCRIPTION
This mixin will strip the `limits` fields of certain containers with very low CPU limits which triggers throttling alerts (see #72). These are quite possibly due to a Kernel bug with CFS and mostly harmless, but the noise caused by the false alarms is undesirable enough to warrant this patch.

Patched containers:
- `addon-resizer`
- `kube-rbac-proxy`
- `kube-rbac-proxy-main`
- `kube-rbac-proxy-self`
- `node-exporter`

To strip the limits on the config reload containers added as sidecars to Prometheus pods, the CLI flag `--config-reloader-cpu=0` is added to the args of the `prometheus-operator` container. 

