### PR TITLE
Bump kube-state-metrics version to 1.6.0

### DIFF
--- a/jsonnet/kube-prometheus/kube-state-metrics/kube-state-metrics.libsonnet
+++ b/jsonnet/kube-prometheus/kube-state-metrics/kube-state-metrics.libsonnet
@@ -16,7 +16,7 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
     },
 
     versions+:: {
-      kubeStateMetrics: 'v1.5.0',
+      kubeStateMetrics: 'v1.6.0',
       kubeRbacProxy: 'v0.4.1',
       addonResizer: '1.8.4',
     },

--- a/jsonnetfile.lock.json
+++ b/jsonnetfile.lock.json
@@ -8,7 +8,7 @@
                     "subdir": "jsonnet/kube-prometheus"
                 }
             },
-            "version": "90b8632fb37be04ff73542218d980ba54c53295b"
+            "version": "6c34ff2d72c3ce5fa265e88bd4a4523e09f64b2a"
         },
         {
             "name": "ksonnet",
@@ -28,7 +28,7 @@
                     "subdir": ""
                 }
             },
-            "version": "d8f135ba007b4ec7ac58be9371042d19e1ae4dea"
+            "version": "3596bcd93d15aad44a8403314c37c2ede04e3d8d"
         },
         {
             "name": "grafonnet",
@@ -48,7 +48,7 @@
                     "subdir": "grafana-builder"
                 }
             },
-            "version": "76258e92c20a2bca74e7f2630c3f8d562919ec86"
+            "version": "45313aeba512858da2974bd44f9adab619cb8f71"
         },
         {
             "name": "grafana",
@@ -68,7 +68,7 @@
                     "subdir": "jsonnet/prometheus-operator"
                 }
             },
-            "version": "f05d5228fe02bcd370acaa234c15f3d9fdef4a60"
+            "version": "6efd4e5e12213021516c10b3ebd0699260ddd804"
         },
         {
             "name": "etcd-mixin",
@@ -78,7 +78,7 @@
                     "subdir": "Documentation/etcd-mixin"
                 }
             },
-            "version": "948e276ca73d3eb09391829d8ac317dbda8c07a1"
+            "version": "d506962fec0337369f194601b8dcd1bf670dda3a"
         }
     ]
 }

--- a/manifests/0prometheus-operator-clusterRole.yaml
+++ b/manifests/0prometheus-operator-clusterRole.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: prometheus-operator
-    app.kubernetes.io/version: v0.31.0
+    app.kubernetes.io/version: v0.31.1
   name: prometheus-operator
 rules:
 - apiGroups:

--- a/manifests/0prometheus-operator-clusterRoleBinding.yaml
+++ b/manifests/0prometheus-operator-clusterRoleBinding.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: prometheus-operator
-    app.kubernetes.io/version: v0.31.0
+    app.kubernetes.io/version: v0.31.1
   name: prometheus-operator
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/manifests/0prometheus-operator-deployment.yaml
+++ b/manifests/0prometheus-operator-deployment.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: prometheus-operator
-    app.kubernetes.io/version: v0.31.0
+    app.kubernetes.io/version: v0.31.1
   name: prometheus-operator
   namespace: monitoring
 spec:
@@ -18,15 +18,15 @@ spec:
       labels:
         app.kubernetes.io/component: controller
         app.kubernetes.io/name: prometheus-operator
-        app.kubernetes.io/version: v0.31.0
+        app.kubernetes.io/version: v0.31.1
     spec:
       containers:
       - args:
         - --kubelet-service=kube-system/kubelet
         - --logtostderr=true
         - --config-reloader-image=quay.io/coreos/configmap-reload:v0.0.1
-        - --prometheus-config-reloader=quay.io/coreos/prometheus-config-reloader:v0.31.0
-        image: quay.io/coreos/prometheus-operator:v0.31.0
+        - --prometheus-config-reloader=quay.io/coreos/prometheus-config-reloader:v0.31.1
+        image: quay.io/coreos/prometheus-operator:v0.31.1
         name: prometheus-operator
         ports:
         - containerPort: 8080

--- a/manifests/0prometheus-operator-service.yaml
+++ b/manifests/0prometheus-operator-service.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: prometheus-operator
-    app.kubernetes.io/version: v0.31.0
+    app.kubernetes.io/version: v0.31.1
   name: prometheus-operator
   namespace: monitoring
 spec:

--- a/manifests/0prometheus-operator-serviceAccount.yaml
+++ b/manifests/0prometheus-operator-serviceAccount.yaml
@@ -4,6 +4,6 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: prometheus-operator
-    app.kubernetes.io/version: v0.31.0
+    app.kubernetes.io/version: v0.31.1
   name: prometheus-operator
   namespace: monitoring

--- a/manifests/0prometheus-operator-serviceMonitor.yaml
+++ b/manifests/0prometheus-operator-serviceMonitor.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: prometheus-operator
-    app.kubernetes.io/version: v0.31.0
+    app.kubernetes.io/version: v0.31.1
   name: prometheus-operator
   namespace: monitoring
 spec:
@@ -15,4 +15,4 @@ spec:
     matchLabels:
       app.kubernetes.io/component: controller
       app.kubernetes.io/name: prometheus-operator
-      app.kubernetes.io/version: v0.31.0
+      app.kubernetes.io/version: v0.31.1

--- a/manifests/kube-state-metrics-deployment.yaml
+++ b/manifests/kube-state-metrics-deployment.yaml
@@ -55,7 +55,7 @@ spec:
         - --port=8081
         - --telemetry-host=127.0.0.1
         - --telemetry-port=8082
-        image: quay.io/coreos/kube-state-metrics:v1.5.0
+        image: quay.io/coreos/kube-state-metrics:v1.6.0
         name: kube-state-metrics
         resources:
           limits:

--- a/manifests/prometheus-rules.yaml
+++ b/manifests/prometheus-rules.yaml
@@ -462,7 +462,7 @@ spec:
           state for longer than an hour.
         runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepodnotready
       expr: |
-        sum by (namespace, pod) (kube_pod_status_phase{job="kube-state-metrics", phase=~"Pending|Unknown"}) > 0
+        sum by (namespace, pod) (kube_pod_status_phase{job="kube-state-metrics", phase=~"Failed|Pending|Unknown"}) > 0
       for: 1h
       labels:
         severity: critical


### PR DESCRIPTION
This bumps to kube-state-metrics [`v1.6.0`](https://github.com/kubernetes/kube-state-metrics/releases/tag/v1.6.0).