### PR TITLE
Update kube-state-metrics.libsonnet

### DIFF
--- a/jsonnet/kube-prometheus/kube-state-metrics/kube-state-metrics.libsonnet
+++ b/jsonnet/kube-prometheus/kube-state-metrics/kube-state-metrics.libsonnet
@@ -67,6 +67,7 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
                                'daemonsets',
                                'deployments',
                                'replicasets',
+                               'ingresses',
                              ]) +
                              rulesType.withVerbs(['list', 'watch']);
 
@@ -115,8 +116,15 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
                            'poddisruptionbudgets',
                          ]) +
                          rulesType.withVerbs(['list', 'watch']);
+                         
+      local certificateRule = rulesType.new() +
+                         rulesType.withApiGroups(['certificates.k8s.io']) +
+                         rulesType.withResources([
+                           'certificatesigningrequests',
+                         ]) +
+                         rulesType.withVerbs(['list', 'watch']);
 
-      local rules = [coreRule, extensionsRule, appsRule, batchRule, autoscalingRule, authenticationRole, authorizationRole, policyRule];
+      local rules = [coreRule, extensionsRule, appsRule, batchRule, autoscalingRule, authenticationRole, authorizationRole, policyRule, certificateRule];
 
       clusterRole.new() +
       clusterRole.mixin.metadata.withName('kube-state-metrics') +


### PR DESCRIPTION
With the bump to kube-state-metrics v1.6 they added ingress and certificates monitoring this updates the rbac rules so that those work with the new version.