### PR TITLE
Fix the Thanos Query deployment to use Thanos Store service

### DIFF
--- a/jsonnetfile.lock.json
+++ b/jsonnetfile.lock.json
@@ -8,7 +8,7 @@
                     "subdir": "jsonnet/kube-prometheus"
                 }
             },
-            "version": "0bc30832d0c7fce4cab6b91eb986cd7c0805f66c"
+            "version": "8a337300704edf3d358d8c140f01275ab2d1b50e"
         },
         {
             "name": "ksonnet",

--- a/manifests/kube-state-metrics-clusterRole.yaml
+++ b/manifests/kube-state-metrics-clusterRole.yaml
@@ -27,6 +27,7 @@ rules:
   - daemonsets
   - deployments
   - replicasets
+  - ingresses
   verbs:
   - list
   - watch
@@ -71,6 +72,13 @@ rules:
   - policy
   resources:
   - poddisruptionbudgets
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - certificates.k8s.io
+  resources:
+  - certificatesigningrequests
   verbs:
   - list
   - watch


### PR DESCRIPTION
1. Thanos Query deployment is bound to 10902 on HTTP not 9090
2. Thanos Query needs Thanos Store address, not Prometheus address
3. Thanos Sidecar Service should really be the Thanos Store Service