### PR TITLE
Add empty podMonitorSelector to Prometheus resource

### DIFF
--- a/jsonnet/kube-prometheus/prometheus/prometheus.libsonnet
+++ b/jsonnet/kube-prometheus/prometheus/prometheus.libsonnet
@@ -170,6 +170,7 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
           baseImage: $._config.imageRepos.prometheus,
           serviceAccountName: 'prometheus-' + $._config.prometheus.name,
           serviceMonitorSelector: {},
+          podMonitorSelector: {},
           serviceMonitorNamespaceSelector: {},
           nodeSelector: { 'beta.kubernetes.io/os': 'linux' },
           ruleSelector: selector.withMatchLabels({

--- a/jsonnetfile.lock.json
+++ b/jsonnetfile.lock.json
@@ -8,7 +8,7 @@
                     "subdir": "jsonnet/kube-prometheus"
                 }
             },
-            "version": "c8c850ef2b1b6f985075ee06fb86b347f9119b16"
+            "version": "a535968c33952ac34db8b37afe6f447b50dc294a"
         },
         {
             "name": "ksonnet",

--- a/manifests/prometheus-prometheus.yaml
+++ b/manifests/prometheus-prometheus.yaml
@@ -14,6 +14,7 @@ spec:
   baseImage: quay.io/prometheus/prometheus
   nodeSelector:
     beta.kubernetes.io/os: linux
+  podMonitorSelector: {}
   replicas: 2
   resources:
     requests:


### PR DESCRIPTION
We want to have `podMonitorSelector: {}` on the Prometheus resource to indicate that Prometheus Operator should select all PodMonitors by default.

/cc @jpkrohling @paulfantom @s-urbaniak @brancz 