### PR TITLE
Remove kube-state-metrics - addonResizer

### DIFF
--- a/jsonnet/kube-prometheus/kube-state-metrics/kube-state-metrics.libsonnet
+++ b/jsonnet/kube-prometheus/kube-state-metrics/kube-state-metrics.libsonnet
@@ -24,7 +24,6 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
     imageRepos+:: {
       kubeStateMetrics: 'quay.io/coreos/kube-state-metrics',
       kubeRbacProxy: 'quay.io/coreos/kube-rbac-proxy',
-      addonResizer: 'k8s.gcr.io/addon-resizer',
     },
   },
 
@@ -174,36 +173,7 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
         container.mixin.resources.withRequests({ cpu: $._config.kubeStateMetrics.baseCPU, memory: $._config.kubeStateMetrics.baseMemory }) +
         container.mixin.resources.withLimits({ cpu: $._config.kubeStateMetrics.baseCPU, memory: $._config.kubeStateMetrics.baseMemory });
 
-      local addonResizer =
-        container.new('addon-resizer', $._config.imageRepos.addonResizer + ':' + $._config.versions.addonResizer) +
-        container.withCommand([
-          '/pod_nanny',
-          '--container=kube-state-metrics',
-          '--cpu=' + $._config.kubeStateMetrics.baseCPU,
-          '--extra-cpu=' + $._config.kubeStateMetrics.cpuPerNode,
-          '--memory=' + $._config.kubeStateMetrics.baseMemory,
-          '--extra-memory=' + $._config.kubeStateMetrics.memoryPerNode,
-          '--threshold=5',
-          '--deployment=kube-state-metrics',
-        ]) +
-        container.withEnv([
-          {
-            name: 'MY_POD_NAME',
-            valueFrom: {
-              fieldRef: { apiVersion: 'v1', fieldPath: 'metadata.name' },
-            },
-          },
-          {
-            name: 'MY_POD_NAMESPACE',
-            valueFrom: {
-              fieldRef: { apiVersion: 'v1', fieldPath: 'metadata.namespace' },
-            },
-          },
-        ]) +
-        container.mixin.resources.withRequests({ cpu: '10m', memory: '30Mi' }) +
-        container.mixin.resources.withLimits({ cpu: '50m', memory: '30Mi' });
-
-      local c = [proxyClusterMetrics, proxySelfMetrics, kubeStateMetrics, addonResizer];
+      local c = [proxyClusterMetrics, proxySelfMetrics, kubeStateMetrics];
 
       deployment.new('kube-state-metrics', 1, c, podLabels) +
       deployment.mixin.metadata.withNamespace($._config.namespace) +

--- a/jsonnetfile.lock.json
+++ b/jsonnetfile.lock.json
@@ -8,7 +8,7 @@
                     "subdir": "jsonnet/kube-prometheus"
                 }
             },
-            "version": "176a187117e56a5ea2ee0f9bbaeee45ddb6f6972"
+            "version": "49ba6611574e02d137846c7b0e7a2ece4e741913"
         },
         {
             "name": "ksonnet",
@@ -38,7 +38,7 @@
                     "subdir": "grafonnet"
                 }
             },
-            "version": "3264a8ab6efa23d55da45ea3a3d3b39e86696c76"
+            "version": "69bc267211790a1c3f4ea6e6211f3e8ffe22f987"
         },
         {
             "name": "grafana-builder",
@@ -48,7 +48,7 @@
                     "subdir": "grafana-builder"
                 }
             },
-            "version": "3daf42722ee2008cae15267ee7380a58988d60cd"
+            "version": "dbc94ab71afa538b2cf467f06751b1836920dce9"
         },
         {
             "name": "grafana",
@@ -78,7 +78,7 @@
                     "subdir": "Documentation/etcd-mixin"
                 }
             },
-            "version": "b2274efee09b49d6cdea7d6d5e6a9c090fc9d8ca"
+            "version": "c5dba11197716f1ca68de53be2aca0bab0ca962b"
         },
         {
             "name": "prometheus",
@@ -88,7 +88,7 @@
                     "subdir": "documentation/prometheus-mixin"
                 }
             },
-            "version": "fb6c709a5e493f003a6dc66bc4c36c2af882de6a"
+            "version": "87a0fe0c75a42d66fcfc82a0ad89bd2549fcfadf"
         }
     ]
 }

--- a/manifests/kube-state-metrics-deployment.yaml
+++ b/manifests/kube-state-metrics-deployment.yaml
@@ -64,35 +64,6 @@ spec:
           requests:
             cpu: 100m
             memory: 150Mi
-      - command:
-        - /pod_nanny
-        - --container=kube-state-metrics
-        - --cpu=100m
-        - --extra-cpu=2m
-        - --memory=150Mi
-        - --extra-memory=30Mi
-        - --threshold=5
-        - --deployment=kube-state-metrics
-        env:
-        - name: MY_POD_NAME
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: metadata.name
-        - name: MY_POD_NAMESPACE
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: metadata.namespace
-        image: k8s.gcr.io/addon-resizer:1.8.4
-        name: addon-resizer
-        resources:
-          limits:
-            cpu: 50m
-            memory: 30Mi
-          requests:
-            cpu: 10m
-            memory: 30Mi
       nodeSelector:
         kubernetes.io/os: linux
       securityContext:


### PR DESCRIPTION
Kube-state-metrics has removed the addon resizer

https://github.com/kubernetes/kube-state-metrics/pull/750
https://github.com/kubernetes/kube-state-metrics/issues/672

This is to fix the issue where addonResizer makes kube-state-metrics constantly trigger scale events for the kube-state-metrics pod

```console
56m         Normal    SuccessfulDelete    replicaset/kube-state-metrics-649755f886   Deleted pod: kube-state-metrics-649755f886-6qwd5
55m         Normal    SuccessfulCreate    replicaset/kube-state-metrics-649755f886   Created pod: kube-state-metrics-649755f886-96qnv
48m         Normal    SuccessfulDelete    replicaset/kube-state-metrics-649755f886   Deleted pod: kube-state-metrics-649755f886-96qnv
48m         Normal    SuccessfulCreate    replicaset/kube-state-metrics-649755f886   Created pod: kube-state-metrics-649755f886-65r5w
23m         Normal    SuccessfulDelete    replicaset/kube-state-metrics-649755f886   Deleted pod: kube-state-metrics-649755f886-65r5w
23m         Normal    SuccessfulCreate    replicaset/kube-state-metrics-649755f886   Created pod: kube-state-metrics-649755f886-td8sm
5m37s       Normal    ScalingReplicaSet   deployment/kube-state-metrics              Scaled up replica set kube-state-metrics-5bfc7db74d to 1
11m         Normal    ScalingReplicaSet   deployment/kube-state-metrics              Scaled down replica set kube-state-metrics-5bfc7db74d to 0
56m         Normal    ScalingReplicaSet   deployment/kube-state-metrics              Scaled down replica set kube-state-metrics-649755f886 to 0
```