### PR TITLE
Fix selectors for Kubernetes 1.14+

### DIFF
--- a/manifests/0prometheus-operator-deployment.yaml
+++ b/manifests/0prometheus-operator-deployment.yaml
@@ -41,7 +41,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
       securityContext:
         runAsNonRoot: true
         runAsUser: 65534

--- a/manifests/grafana-deployment.yaml
+++ b/manifests/grafana-deployment.yaml
@@ -97,7 +97,7 @@ spec:
           name: grafana-dashboard-statefulset
           readOnly: false
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
       securityContext:
         runAsNonRoot: true
         runAsUser: 65534


### PR DESCRIPTION
According to [comment](https://github.com/coreos/kube-prometheus/issues/161#issuecomment-514432211) in issue #161 for Kubernetes 1.14+ selector `kubernetes.io/os` should be used instead `beta.kubernetes.io/os`