### PR TITLE
Drop container_* metrics with no image.

### DIFF
--- a/jsonnet/kube-prometheus/prometheus/prometheus.libsonnet
+++ b/jsonnet/kube-prometheus/prometheus/prometheus.libsonnet
@@ -285,6 +285,12 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
               },
               bearerTokenFile: '/var/run/secrets/kubernetes.io/serviceaccount/token',
               metricRelabelings: [
+                // Drop container_* metrics with no image.
+                {
+                  sourceLabels: ['__name__', 'image'],
+                  regex: 'container_([a-z_]+);',
+                  action: 'drop',
+                },
                 // Drop a bunch of metrics which are disabled but still sent, see
                 // https://github.com/google/cadvisor/issues/1925.
                 {

--- a/jsonnetfile.lock.json
+++ b/jsonnetfile.lock.json
@@ -8,7 +8,7 @@
                     "subdir": "jsonnet/kube-prometheus"
                 }
             },
-            "version": "e7d1ada77544feda4c265c705e1afa7927f6e8ab"
+            "version": "cedb5dec87f58978bca05c08b80bf334df3ae53f"
         },
         {
             "name": "ksonnet",
@@ -28,7 +28,7 @@
                     "subdir": ""
                 }
             },
-            "version": "3cf3741fcb8aad72e0d4cb351ef3712a5df58d0f"
+            "version": "167bd42bbd6ae567e6a6f04a60b27322624cdd81"
         },
         {
             "name": "grafonnet",
@@ -48,7 +48,7 @@
                     "subdir": "grafana-builder"
                 }
             },
-            "version": "c6c1ff2725c07c55fa56e26f7edc451ce1643170"
+            "version": "1d62ade029fe7667f88e55b102717993ebafca29"
         },
         {
             "name": "grafana",
@@ -78,7 +78,7 @@
                     "subdir": "Documentation/etcd-mixin"
                 }
             },
-            "version": "0d85aa1b417a7c9646c42130b5d4df8a5aea2714"
+            "version": "03bd10076fe4731d7ea72dffff0ff80b3ca6d2f3"
         },
         {
             "name": "prometheus",
@@ -88,7 +88,7 @@
                     "subdir": "documentation/prometheus-mixin"
                 }
             },
-            "version": "41151ca8dc069448515f48893b8631b9a3ad8df8"
+            "version": "ff40de7ca6084f5aab1f3971025c00c217615589"
         }
     ]
 }

--- a/manifests/prometheus-serviceMonitorKubelet.yaml
+++ b/manifests/prometheus-serviceMonitorKubelet.yaml
@@ -19,6 +19,11 @@ spec:
     interval: 30s
     metricRelabelings:
     - action: drop
+      regex: container_([a-z_]+);
+      sourceLabels:
+      - __name__
+      - image
+    - action: drop
       regex: container_(network_tcp_usage_total|network_udp_usage_total|tasks_state|cpu_load_average_10s)
       sourceLabels:
       - __name__


### PR DESCRIPTION
some metrics related to container is collected twice.
My issue:
https://github.com/helm/charts/issues/16121
Related issue:
https://github.com/kubernetes-monitoring/kubernetes-mixin/issues/136


Despite [the solution is known](https://github.com/kubernetes-monitoring/kubernetes-mixin/issues/136#issuecomment-456033706), no one seems to send a pull request.