### PR TITLE
Fix io time yaxe

### DIFF
--- a/jsonnetfile.lock.json
+++ b/jsonnetfile.lock.json
@@ -28,7 +28,7 @@
                     "subdir": ""
                 }
             },
-            "version": "3cf3741fcb8aad72e0d4cb351ef3712a5df58d0f"
+            "version": "0afc72e70df6048c6b65fd3e4968e53b0812b30c"
         },
         {
             "name": "grafonnet",

--- a/manifests/grafana-dashboardDefinitions.yaml
+++ b/manifests/grafana-dashboardDefinitions.yaml
@@ -12793,7 +12793,7 @@ items:
                                   "show": true
                               },
                               {
-                                  "format": "ms",
+                                  "format": "s",
                                   "label": null,
                                   "logBase": 1,
                                   "max": null,

--- a/manifests/prometheus-rules.yaml
+++ b/manifests/prometheus-rules.yaml
@@ -23,13 +23,6 @@ spec:
       record: namespace:container_memory_usage_bytes:sum
     - expr: |
         sum by (namespace, label_name) (
-            sum(rate(container_cpu_usage_seconds_total{job="kubelet", image!="", container!="POD"}[5m])) by (namespace, pod)
-          * on (namespace, pod)
-            group_left(label_name) kube_pod_labels{job="kube-state-metrics"}
-        )
-      record: namespace:container_cpu_usage_seconds_total:sum_rate
-    - expr: |
-        sum by (namespace, label_name) (
             sum(container_memory_usage_bytes{job="kubelet",image!="", container!="POD"}) by (pod, namespace)
           * on (namespace, pod)
             group_left(label_name) kube_pod_labels{job="kube-state-metrics"}


### PR DESCRIPTION
The upstream has be updated and fixed kubernetes-monitoring/kubernetes-mixin#235 , so the new generated manifests should be good, but in case that someone will use the generated manifests directly, I guess it would be better to update the manifests?