### PR TITLE
set kubeStateMetrics version to 1.7.2

### DIFF
--- a/jsonnet/kube-prometheus/kube-state-metrics/kube-state-metrics.libsonnet
+++ b/jsonnet/kube-prometheus/kube-state-metrics/kube-state-metrics.libsonnet
@@ -16,7 +16,7 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
     },
 
     versions+:: {
-      kubeStateMetrics: 'v1.7.1',
+      kubeStateMetrics: 'v1.7.2',
       kubeRbacProxy: 'v0.4.1',
       addonResizer: '1.8.4',
     },


### PR DESCRIPTION
to avoid using the vulnerable version of `kube-state-metrics`

https://github.com/kubernetes/kube-state-metrics/releases/tag/v1.7.2