### PR TITLE
Use local dependency for kube-prometheus jsonnet

### DIFF
--- a/jsonnetfile.json
+++ b/jsonnetfile.json
@@ -3,12 +3,11 @@
         {
             "name": "kube-prometheus",
             "source": {
-                "git": {
-                    "remote": ".",
-                    "subdir": "jsonnet/kube-prometheus"
+                "local": {
+                    "directory": "jsonnet/kube-prometheus"
                 }
             },
-            "version": "."
+            "version": ""
         }
     ]
 }

--- a/jsonnetfile.lock.json
+++ b/jsonnetfile.lock.json
@@ -3,12 +3,11 @@
         {
             "name": "kube-prometheus",
             "source": {
-                "git": {
-                    "remote": ".",
-                    "subdir": "jsonnet/kube-prometheus"
+                "local": {
+                    "directory": "jsonnet/kube-prometheus"
                 }
             },
-            "version": "34cdedde438de454c1fa3a7f04d1048b89374bff"
+            "version": ""
         },
         {
             "name": "ksonnet",

--- a/manifests/node-exporter-daemonset.yaml
+++ b/manifests/node-exporter-daemonset.yaml
@@ -26,7 +26,7 @@ spec:
         name: node-exporter
         resources:
           limits:
-            cpu: 250m
+            cpu: 102m
             memory: 180Mi
           requests:
             cpu: 102m


### PR DESCRIPTION
Once we merge https://github.com/jsonnet-bundler/jsonnet-bundler/pull/36 we can make use of local dependencies with jsonnet-bundler.
Before the build for this PR in the CI succeeds, we need to update `jb` in the CI image (/cc @paulfantom).

/cc @brancz @LiliC @s-urbaniak @squat 