### PR TITLE
Add labels for namespace and service to TargetDown

### DIFF
--- a/jsonnet/kube-prometheus/alerts/general.libsonnet
+++ b/jsonnet/kube-prometheus/alerts/general.libsonnet
@@ -9,7 +9,7 @@
             annotations: {
               message: '{{ $value }}% of the {{ $labels.job }} targets are down.',
             },
-            expr: '100 * (count(up == 0) BY (job) / count(up) BY (job)) > 10',
+            expr: '100 * (count(up == 0) BY (job, namespace, service) / count(up) BY (job, namespace, service)) > 10',
             'for': '10m',
             labels: {
               severity: 'warning',

--- a/manifests/prometheus-rules.yaml
+++ b/manifests/prometheus-rules.yaml
@@ -1124,7 +1124,8 @@ spec:
     - alert: TargetDown
       annotations:
         message: '{{ $value }}% of the {{ $labels.job }} targets are down.'
-      expr: 100 * (count(up == 0) BY (job) / count(up) BY (job)) > 10
+      expr: 100 * (count(up == 0) BY (job, namespace, service) / count(up) BY (job,
+        namespace, service)) > 10
       for: 10m
       labels:
         severity: warning


### PR DESCRIPTION
Idea from here https://github.com/alphagov/gsp/pull/328

This enables alerts for down targets to have fields such as namespace and service