### PR TITLE
use real alertmanager name

### DIFF
--- a/jsonnet/kube-prometheus/kube-prometheus.libsonnet
+++ b/jsonnet/kube-prometheus/kube-prometheus.libsonnet
@@ -89,7 +89,7 @@ local configMapList = k3.core.v1.configMapList;
     coreDNSSelector: 'job="kube-dns"',
     podLabel: 'pod',
 
-    alertmanagerSelector: 'job="alertmanager-main",namespace="' + $._config.namespace + '"',
+    alertmanagerSelector: 'job="alertmanager-' + $._config.alertmanager.name + '",namespace="' + $._config.namespace + '"',
     prometheusSelector: 'job="prometheus-' + $._config.prometheus.name + '",namespace="' + $._config.namespace + '"',
     prometheusName: '{{$labels.namespace}}/{{$labels.pod}}',
     prometheusOperatorSelector: 'job="prometheus-operator",namespace="' + $._config.namespace + '"',


### PR DESCRIPTION
`alertmanager-main` is hardcoded where it should derive from the real alertmanager name as defined by the user

This also apply to the release branch...