### PR TITLE
jsonnet/kube-prometheus: Prevent many-to-many matching

### DIFF
--- a/jsonnet/kube-prometheus/alerts/alertmanager.libsonnet
+++ b/jsonnet/kube-prometheus/alerts/alertmanager.libsonnet
@@ -10,7 +10,7 @@
               message: 'The configuration of the instances of the Alertmanager cluster `{{$labels.service}}` are out of sync.',
             },
             expr: |||
-              count_values("config_hash", alertmanager_config_hash{%(alertmanagerSelector)s}) BY (service) / ON(service) GROUP_LEFT() label_replace(prometheus_operator_spec_replicas{%(prometheusOperatorSelector)s,controller="alertmanager"}, "service", "alertmanager-$1", "name", "(.*)") != 1
+              count_values("config_hash", alertmanager_config_hash{%(alertmanagerSelector)s}) BY (service) / ON(service) GROUP_LEFT() label_replace(max(prometheus_operator_spec_replicas{%(prometheusOperatorSelector)s,controller="alertmanager"}) by (name, job, namespace, controller), "service", "alertmanager-$1", "name", "(.*)") != 1
             ||| % $._config,
             'for': '5m',
             labels: {
@@ -31,8 +31,8 @@
             },
           },
           {
-            alert:'AlertmanagerMembersInconsistent',
-            annotations:{
+            alert: 'AlertmanagerMembersInconsistent',
+            annotations: {
               message: 'Alertmanager has not found all other members of the cluster.',
             },
             expr: |||

--- a/jsonnetfile.lock.json
+++ b/jsonnetfile.lock.json
@@ -8,7 +8,7 @@
                     "subdir": "jsonnet/kube-prometheus"
                 }
             },
-            "version": "2fde1a442df6b6b5851c47b3bc5fb537090c570c"
+            "version": "579dbf34b159c1709f1b63d593aba90925fa72ea"
         },
         {
             "name": "ksonnet",

--- a/manifests/prometheus-rules.yaml
+++ b/manifests/prometheus-rules.yaml
@@ -854,7 +854,7 @@ spec:
         message: The configuration of the instances of the Alertmanager cluster `{{$labels.service}}`
           are out of sync.
       expr: |
-        count_values("config_hash", alertmanager_config_hash{job="alertmanager-main",namespace="monitoring"}) BY (service) / ON(service) GROUP_LEFT() label_replace(prometheus_operator_spec_replicas{job="prometheus-operator",namespace="monitoring",controller="alertmanager"}, "service", "alertmanager-$1", "name", "(.*)") != 1
+        count_values("config_hash", alertmanager_config_hash{job="alertmanager-main",namespace="monitoring"}) BY (service) / ON(service) GROUP_LEFT() label_replace(max(prometheus_operator_spec_replicas{job="prometheus-operator",namespace="monitoring",controller="alertmanager"}) by (name, job, namespace, controller), "service", "alertmanager-$1", "name", "(.*)") != 1
       for: 5m
       labels:
         severity: critical


### PR DESCRIPTION
We need this change in the release-0.1 branch to be able to backport this to CMO release-4.1. I think this is the right way to go about doing this.

https://github.com/coreos/kube-prometheus/pull/186

cc @metalmatze @s-urbaniak @paulfantom 