### PR TITLE
Fix unmatched, misplaced braces

### DIFF
--- a/manifests/grafana-dashboardDefinitions.yaml
+++ b/manifests/grafana-dashboardDefinitions.yaml
@@ -19485,7 +19485,7 @@ items:
                       "options": [
 
                       ],
-                      "query": "label_values(kube_statefulset_metadata_generation{job=\"kube-state-metrics\"}, cluster=\"$cluster\", namespace)",
+                      "query": "label_values(kube_statefulset_metadata_generation{job=\"kube-state-metrics\", cluster=\"$cluster\"}, namespace)",
                       "refresh": 2,
                       "regex": "",
                       "sort": 0,

--- a/manifests/grafana-dashboardDefinitions.yaml
+++ b/manifests/grafana-dashboardDefinitions.yaml
@@ -11911,7 +11911,7 @@ items:
                           "steppedLine": false,
                           "targets": [
                               {
-                                  "expr": "1 -\n(\n  max without (mountpoint, fstype) (node_filesystem_avail_bytes{job=\"node-exporter\", , instance=\"$instance\"}})\n/\n  max without (mountpoint, fstype) (node_filesystem_size_bytes{job=\"node-exporter\", , instance=\"$instance\"}})\n)\n",
+                                  "expr": "1 -\n(\n  max without (mountpoint, fstype) (node_filesystem_avail_bytes{job=\"node-exporter\", instance=\"$instance\"})\n/\n  max without (mountpoint, fstype) (node_filesystem_size_bytes{job=\"node-exporter\", instance=\"$instance\"})\n)\n",
                                   "format": "time_series",
                                   "intervalFactor": 2,
                                   "legendFormat": "{{device}}",


### PR DESCRIPTION
I noticed some components in the dashboard were broken, namely, Kubernetes / StatefulSets 
and Disk Space Utilisation at USE Method / Node. I don't know if the person who wrote it left the trailing commas on purpose, but removing it made it work.