### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ local kp =
   // (import 'kube-prometheus/kube-prometheus-managed-cluster.libsonnet') +
   // (import 'kube-prometheus/kube-prometheus-node-ports.libsonnet') +
   // (import 'kube-prometheus/kube-prometheus-static-etcd.libsonnet') +
-  // (import 'kube-prometheus/kube-prometheus-thanos-sidecar.libsonnet') +
+  // (import 'kube-prometheus/kube-prometheus-thanos.libsonnet') +
   {
     _config+:: {
       namespace: 'monitoring',


### PR DESCRIPTION
The `example.jsonnet` is out of date for thanos libsonnet. I got blow error when I uncommented thanos libsonnet import:
```
RUNTIME ERROR: couldn't open import "kube-prometheus/kube-prometheus-thanos-sidecar.libsonnet": no match locally or in the Jsonnet library paths
	my-kube-prom.jsonnet:8:4-69	thunk <kp> from <$>
	my-kube-prom.jsonnet:15:81-83
	<std>:1268:24-25	thunk from <function <anonymous>>
	<std>:1268:5-33	function <anonymous>
	my-kube-prom.jsonnet:15:64-99	$
```