### PR TITLE
Kubespray deploys CoreDNS with label k8s-app=kube-dns

### DIFF
--- a/jsonnet/kube-prometheus/kube-prometheus-kubespray.libsonnet
+++ b/jsonnet/kube-prometheus/kube-prometheus-kubespray.libsonnet
@@ -4,12 +4,6 @@ local servicePort = k.core.v1.service.mixin.spec.portsType;
 
 {
 
-  _config+:: {
-    jobs+: {
-      CoreDNS: 'job="coredns"',
-    },
-  },
-
   prometheus+: {
     kubeControllerManagerPrometheusDiscoveryService:
       service.new('kube-controller-manager-prometheus-discovery', { 'component': 'kube-controller-manager' }, servicePort.newNamed('http-metrics', 10252, 10252)) +
@@ -21,16 +15,6 @@ local servicePort = k.core.v1.service.mixin.spec.portsType;
       service.mixin.metadata.withNamespace('kube-system') +
       service.mixin.metadata.withLabels({ 'k8s-app': 'kube-scheduler' }) +
       service.mixin.spec.withClusterIp('None'),
-
-    serviceMonitorCoreDNS+: {
-      spec+: {
-        selector: {
-          matchLabels: {
-            'k8s-app': 'coredns',
-          },
-        },
-      },
-    },
 
     serviceMonitorKubeScheduler+: {
       spec+: {


### PR DESCRIPTION
Since commit kubernetes-sigs/kubespray@6caa639243bf217bdb4e5925d4da868ca1d1b6ef Kubespray uses the standard k8s-app=kube-dns for CoreDNS.

This PR removes overloads in order to use kube-prometheus' default.