### PR TITLE
Update rules to work with new kube-state-metrics

### DIFF
--- a/manifests/prometheus-rules.yaml
+++ b/manifests/prometheus-rules.yaml
@@ -83,16 +83,16 @@ spec:
         sum(container_memory_usage_bytes{job="kubelet", image!="", container!="POD"}) by (namespace)
       record: namespace:container_memory_usage_bytes:sum
     - expr: |
-        sum by (namespace, label_name) (
-            sum(kube_pod_container_resource_requests_memory_bytes{job="kube-state-metrics"} * on (endpoint, instance, job, namespace, pod, service) group_left(phase) (kube_pod_status_phase{phase=~"^(Pending|Running)$"} == 1)) by (namespace, pod)
-          * on (namespace, pod)
+        sum by (exported_namespace, label_name) (
+            sum(kube_pod_container_resource_requests_memory_bytes{job="kube-state-metrics"} * on (endpoint, instance, job, exported_namespace, exported_pod, service) group_left(phase) (kube_pod_status_phase{phase=~"^(Pending|Running)$"} == 1)) by (exported_namespace, exported_pod)
+          * on (exported_namespace, exported_pod)
             group_left(label_name) kube_pod_labels{job="kube-state-metrics"}
         )
       record: namespace:kube_pod_container_resource_requests_memory_bytes:sum
     - expr: |
-        sum by (namespace, label_name) (
-            sum(kube_pod_container_resource_requests_cpu_cores{job="kube-state-metrics"} * on (endpoint, instance, job, namespace, pod, service) group_left(phase) (kube_pod_status_phase{phase=~"^(Pending|Running)$"} == 1)) by (namespace, pod)
-          * on (namespace, pod)
+        sum by (exported_namespace, label_name) (
+            sum(kube_pod_container_resource_requests_cpu_cores{job="kube-state-metrics"} * on (endpoint, instance, job, exported_namespace, exported_pod, service) group_left(phase) (kube_pod_status_phase{phase=~"^(Pending|Running)$"} == 1)) by (exported_namespace, exported_pod)
+          * on (exported_namespace, exported_pod)
             group_left(label_name) kube_pod_labels{job="kube-state-metrics"}
         )
       record: namespace:kube_pod_container_resource_requests_cpu_cores:sum
@@ -105,7 +105,7 @@ spec:
             ) * on(replicaset, namespace) group_left(owner_name) kube_replicaset_owner{job="kube-state-metrics"},
             "workload", "$1", "owner_name", "(.*)"
           )
-        ) by (namespace, workload, pod)
+        ) by (exported_namespace, workload, exported_pod)
       labels:
         workload_type: deployment
       record: mixin_pod_workload
@@ -115,7 +115,7 @@ spec:
             kube_pod_owner{job="kube-state-metrics", owner_kind="DaemonSet"},
             "workload", "$1", "owner_name", "(.*)"
           )
-        ) by (namespace, workload, pod)
+        ) by (exported_namespace, workload, exported_pod)
       labels:
         workload_type: daemonset
       record: mixin_pod_workload
@@ -125,7 +125,7 @@ spec:
             kube_pod_owner{job="kube-state-metrics", owner_kind="StatefulSet"},
             "workload", "$1", "owner_name", "(.*)"
           )
-        ) by (namespace, workload, pod)
+        ) by (exported_namespace, workload, exported_pod)
       labels:
         workload_type: statefulset
       record: mixin_pod_workload
@@ -198,12 +198,12 @@ spec:
     - expr: sum(min(kube_pod_info) by (node))
       record: ':kube_pod_info_node_count:'
     - expr: |
-        max(label_replace(kube_pod_info{job="kube-state-metrics"}, "pod", "$1", "pod", "(.*)")) by (node, namespace, pod)
+        max(label_replace(kube_pod_info{job="kube-state-metrics"}, "exported_pod", "$1", "exported_pod", "(.*)")) by (node, exported_namespace, exported_pod)
       record: 'node_namespace_pod:kube_pod_info:'
     - expr: |
         count by (node) (sum by (node, cpu) (
           node_cpu_seconds_total{job="node-exporter"}
-        * on (namespace, pod) group_left(node)
+        * on (exported_namespace, exported_pod) group_left(node)
           node_namespace_pod:kube_pod_info:
         ))
       record: node:node_num_cpu:sum
@@ -497,7 +497,7 @@ spec:
           state for longer than 15 minutes.
         runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepodnotready
       expr: |
-        sum by (namespace, pod) (kube_pod_status_phase{job="kube-state-metrics", phase=~"Failed|Pending|Unknown"}) > 0
+        sum by (exported_namespace, exported_pod) (kube_pod_status_phase{job="kube-state-metrics", phase=~"Failed|Pending|Unknown"}) > 0
       for: 15m
       labels:
         severity: critical


### PR DESCRIPTION
kube-state-metrics has renamed namespace and pod to exported_namespace and exported_pod which caused some of the rules to be either failing with duplicate time series error or report wrong values