### PR TITLE
jsonnet/kube-prometheus/kube-state-metrics: Drop ksm own labels

### DIFF
--- a/jsonnet/kube-prometheus/kube-state-metrics/kube-state-metrics.libsonnet
+++ b/jsonnet/kube-prometheus/kube-state-metrics/kube-state-metrics.libsonnet
@@ -310,6 +310,12 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
               scrapeTimeout: $._config.kubeStateMetrics.scrapeTimeout,
               honorLabels: true,
               bearerTokenFile: '/var/run/secrets/kubernetes.io/serviceaccount/token',
+              relabelings: [
+                {
+                  regex: '(pod|service|job|endpoint|namespace)',
+                  action: 'labeldrop',
+                },
+              ],
               tlsConfig: {
                 insecureSkipVerify: true,
               },

--- a/manifests/kube-state-metrics-serviceMonitor.yaml
+++ b/manifests/kube-state-metrics-serviceMonitor.yaml
@@ -11,6 +11,9 @@ spec:
     honorLabels: true
     interval: 30s
     port: https-main
+    relabelings:
+    - action: labeldrop
+      regex: (pod|service|job|endpoint|namespace)
     scheme: https
     scrapeTimeout: 30s
     tlsConfig:


### PR DESCRIPTION
This PR drops the labels specific to kube-state-metrics pod from kube-state-metrics metrics. These labels are misleading as they are about the kube-state-metrics pod, now about the resources themselves.

Before:
```
kube_replicaset_metadata_generation{endpoint=“https-main”,instance=“1234:8443",job=“kube-state-metrics”,namespace=“cert-manager”,pod=“kube-state-metrics-64c4bdf979-tlzjr”,replicaset=“cert-manager-b9748ff89",service=“kube-state-metrics”}
```
After:
```
kube_replicaset_metadata_generation{instance=“1234:8443”,namespace=“kube-system”,replicaset=“coredns-584795fc57”}
```

Question: Not sure if the instance label is about the ksm pod node or the resource node?

cc @brancz 