### PR TITLE
jsonnet/kube-prometheus/alerts: improve TargetDown message

### DIFF
--- a/jsonnet/kube-prometheus/alerts/general.libsonnet
+++ b/jsonnet/kube-prometheus/alerts/general.libsonnet
@@ -7,7 +7,7 @@
           {
             alert: 'TargetDown',
             annotations: {
-              message: '{{ $value }}% of the {{ $labels.job }} targets are down.',
+              message: '{{ printf "%.4g" $value }}% of the {{ $labels.job }} targets are down.',
             },
             expr: '100 * (count(up == 0) BY (job, namespace, service) / count(up) BY (job, namespace, service)) > 10',
             'for': '10m',

--- a/manifests/prometheus-rules.yaml
+++ b/manifests/prometheus-rules.yaml
@@ -1123,7 +1123,8 @@ spec:
     rules:
     - alert: TargetDown
       annotations:
-        message: '{{ $value }}% of the {{ $labels.job }} targets are down.'
+        message: '{{ printf "%.4g" $value }}% of the {{ $labels.job }} targets are
+          down.'
       expr: 100 * (count(up == 0) BY (job, namespace, service) / count(up) BY (job,
         namespace, service)) > 10
       for: 10m


### PR DESCRIPTION
Before:

```
16.666666666666664% of the sdn targets are down.
```

After

```
16.67% of the sdn targets are down.
```