### PR TITLE
jsonnet/kube-prometheus/kube-state-metrics: Do not drop job label

### DIFF
--- a/jsonnet/kube-prometheus/kube-state-metrics/kube-state-metrics.libsonnet
+++ b/jsonnet/kube-prometheus/kube-state-metrics/kube-state-metrics.libsonnet
@@ -279,7 +279,7 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
               bearerTokenFile: '/var/run/secrets/kubernetes.io/serviceaccount/token',
               relabelings: [
                 {
-                  regex: '(pod|service|job|endpoint|namespace)',
+                  regex: '(pod|service|endpoint|namespace)',
                   action: 'labeldrop',
                 },
               ],

--- a/manifests/kube-state-metrics-serviceMonitor.yaml
+++ b/manifests/kube-state-metrics-serviceMonitor.yaml
@@ -13,7 +13,7 @@ spec:
     port: https-main
     relabelings:
     - action: labeldrop
-      regex: (pod|service|job|endpoint|namespace)
+      regex: (pod|service|endpoint|namespace)
     scheme: https
     scrapeTimeout: 30s
     tlsConfig:


### PR DESCRIPTION
This broke some alerts, as they are using the `job="kube-state-metrics"` label. We should first remove that label from the alerts and then drop this label. For now, lets "revert" the job label dropping.

cc @brancz 