### PR TITLE
Grafana dashboard update for release-0.1

### DIFF
--- a/jsonnetfile.json
+++ b/jsonnetfile.json
@@ -3,12 +3,11 @@
         {
             "name": "kube-prometheus",
             "source": {
-                "git": {
-                    "remote": ".",
-                    "subdir": "jsonnet/kube-prometheus"
+                "local": {
+                    "directory": "jsonnet/kube-prometheus"
                 }
             },
-            "version": "."
+            "version": ""
         }
     ]
 }

--- a/jsonnetfile.lock.json
+++ b/jsonnetfile.lock.json
@@ -7,7 +7,7 @@
                     "directory": "jsonnet/kube-prometheus"
                 }
             },
-            "version": "34cdedde438de454c1fa3a7f04d1048b89374bff"
+            "version": ""
         },
         {
             "name": "ksonnet",
@@ -27,7 +27,7 @@
                     "subdir": ""
                 }
             },
-            "version": "218206a13685626213f3836235e9a81a9384a01e"
+            "version": "d0e069002ba767676145fe5e29325720669499c6"
         },
         {
             "name": "grafonnet",
@@ -37,7 +37,7 @@
                     "subdir": "grafonnet"
                 }
             },
-            "version": "69bc267211790a1c3f4ea6e6211f3e8ffe22f987"
+            "version": "47db72da03fc4a7a0658a87791e13c3315a3a252"
         },
         {
             "name": "grafana-builder",
@@ -47,7 +47,7 @@
                     "subdir": "grafana-builder"
                 }
             },
-            "version": "2b9b14d0d91adf8781e5b2c9b62dc8cb180a9886"
+            "version": "3fe9a46d5fe0b70cbcabec1d2054f8ac3b3faae7"
         },
         {
             "name": "grafana",
@@ -57,7 +57,7 @@
                     "subdir": "grafana"
                 }
             },
-            "version": "7fadaf2274d5cbe4ac6fbaf8786e4b7ecf3c1713"
+            "version": "a5c2b4da6ca92064604d5a8a893dec07ddead136"
         },
         {
             "name": "prometheus-operator",
@@ -77,7 +77,7 @@
                     "subdir": "Documentation/etcd-mixin"
                 }
             },
-            "version": "6075b9def1315242e66509439f1b92845cf47a90"
+            "version": "9c48dfabff597b086cc98f34c960b77a0c569551"
         }
     ]
 }

--- a/jsonnetfile.lock.json
+++ b/jsonnetfile.lock.json
@@ -3,12 +3,11 @@
         {
             "name": "kube-prometheus",
             "source": {
-                "git": {
-                    "remote": ".",
-                    "subdir": "jsonnet/kube-prometheus"
+                "local": {
+                    "directory": "jsonnet/kube-prometheus"
                 }
             },
-            "version": "1a4c7591220febb47a8af3cc2150c5483189bf6e"
+            "version": "34cdedde438de454c1fa3a7f04d1048b89374bff"
         },
         {
             "name": "ksonnet",

--- a/manifests/grafana-dashboardDefinitions.yaml
+++ b/manifests/grafana-dashboardDefinitions.yaml
@@ -64,7 +64,7 @@ items:
                                   "format": "time_series",
                                   "intervalFactor": 2,
                                   "legendFormat": "{{node}}",
-                                  "legendLink": "/d/4ac4f123aae0ff6dbaf4f4f66120033b/k8s-node-rsrc-use",
+                                  "legendLink": "./d/4ac4f123aae0ff6dbaf4f4f66120033b/k8s-node-rsrc-use",
                                   "step": 10
                               }
                           ],
@@ -150,7 +150,7 @@ items:
                                   "format": "time_series",
                                   "intervalFactor": 2,
                                   "legendFormat": "{{node}}",
-                                  "legendLink": "/d/4ac4f123aae0ff6dbaf4f4f66120033b/k8s-node-rsrc-use",
+                                  "legendLink": "./d/4ac4f123aae0ff6dbaf4f4f66120033b/k8s-node-rsrc-use",
                                   "step": 10
                               }
                           ],
@@ -248,7 +248,7 @@ items:
                                   "format": "time_series",
                                   "intervalFactor": 2,
                                   "legendFormat": "{{node}}",
-                                  "legendLink": "/d/4ac4f123aae0ff6dbaf4f4f66120033b/k8s-node-rsrc-use",
+                                  "legendLink": "./d/4ac4f123aae0ff6dbaf4f4f66120033b/k8s-node-rsrc-use",
                                   "step": 10
                               }
                           ],
@@ -334,7 +334,7 @@ items:
                                   "format": "time_series",
                                   "intervalFactor": 2,
                                   "legendFormat": "{{node}}",
-                                  "legendLink": "/d/4ac4f123aae0ff6dbaf4f4f66120033b/k8s-node-rsrc-use",
+                                  "legendLink": "./d/4ac4f123aae0ff6dbaf4f4f66120033b/k8s-node-rsrc-use",
                                   "step": 10
                               }
                           ],
@@ -432,7 +432,7 @@ items:
                                   "format": "time_series",
                                   "intervalFactor": 2,
                                   "legendFormat": "{{node}}",
-                                  "legendLink": "/d/4ac4f123aae0ff6dbaf4f4f66120033b/k8s-node-rsrc-use",
+                                  "legendLink": "./d/4ac4f123aae0ff6dbaf4f4f66120033b/k8s-node-rsrc-use",
                                   "step": 10
                               }
                           ],
@@ -518,7 +518,7 @@ items:
                                   "format": "time_series",
                                   "intervalFactor": 2,
                                   "legendFormat": "{{node}}",
-                                  "legendLink": "/d/4ac4f123aae0ff6dbaf4f4f66120033b/k8s-node-rsrc-use",
+                                  "legendLink": "./d/4ac4f123aae0ff6dbaf4f4f66120033b/k8s-node-rsrc-use",
                                   "step": 10
                               }
                           ],
@@ -616,7 +616,7 @@ items:
                                   "format": "time_series",
                                   "intervalFactor": 2,
                                   "legendFormat": "{{node}}",
-                                  "legendLink": "/d/4ac4f123aae0ff6dbaf4f4f66120033b/k8s-node-rsrc-use",
+                                  "legendLink": "./d/4ac4f123aae0ff6dbaf4f4f66120033b/k8s-node-rsrc-use",
                                   "step": 10
                               }
                           ],
@@ -702,7 +702,7 @@ items:
                                   "format": "time_series",
                                   "intervalFactor": 2,
                                   "legendFormat": "{{node}}",
-                                  "legendLink": "/d/4ac4f123aae0ff6dbaf4f4f66120033b/k8s-node-rsrc-use",
+                                  "legendLink": "./d/4ac4f123aae0ff6dbaf4f4f66120033b/k8s-node-rsrc-use",
                                   "step": 10
                               }
                           ],
@@ -800,7 +800,7 @@ items:
                                   "format": "time_series",
                                   "intervalFactor": 2,
                                   "legendFormat": "{{node}}",
-                                  "legendLink": "/d/4ac4f123aae0ff6dbaf4f4f66120033b/k8s-node-rsrc-use",
+                                  "legendLink": "./d/4ac4f123aae0ff6dbaf4f4f66120033b/k8s-node-rsrc-use",
                                   "step": 10
                               }
                           ],
@@ -891,7 +891,7 @@ items:
                       "options": [
 
                       ],
-                      "query": "label_values(kube_node_info, cluster)",
+                      "query": "label_values(:kube_pod_info_node_count:, cluster)",
                       "refresh": 1,
                       "regex": "",
                       "sort": 2,
@@ -1834,7 +1834,7 @@ items:
                       "options": [
 
                       ],
-                      "query": "label_values(kube_node_info, cluster)",
+                      "query": "label_values(:kube_pod_info_node_count:, cluster)",
                       "refresh": 1,
                       "regex": "",
                       "sort": 2,
@@ -2602,7 +2602,7 @@ items:
                                   "decimals": 0,
                                   "link": true,
                                   "linkTooltip": "Drill down to pods",
-                                  "linkUrl": "/d/85a562078cdf77779eaa1add43ccec1e/k8s-resources-namespace?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$__cell_1",
+                                  "linkUrl": "./d/85a562078cdf77779eaa1add43ccec1e/k8s-resources-namespace?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$__cell_1",
                                   "pattern": "Value #A",
                                   "thresholds": [
 
@@ -2620,7 +2620,7 @@ items:
                                   "decimals": 0,
                                   "link": true,
                                   "linkTooltip": "Drill down to workloads",
-                                  "linkUrl": "/d/a87fb0d919ec0ea5f6543124e16c42a5/k8s-resources-workloads-namespace?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$__cell_1",
+                                  "linkUrl": "./d/a87fb0d919ec0ea5f6543124e16c42a5/k8s-resources-workloads-namespace?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$__cell_1",
                                   "pattern": "Value #B",
                                   "thresholds": [
 
@@ -2728,7 +2728,7 @@ items:
                                   "decimals": 2,
                                   "link": true,
                                   "linkTooltip": "Drill down to pods",
-                                  "linkUrl": "/d/85a562078cdf77779eaa1add43ccec1e/k8s-resources-namespace?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$__cell",
+                                  "linkUrl": "./d/85a562078cdf77779eaa1add43ccec1e/k8s-resources-namespace?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$__cell",
                                   "pattern": "namespace",
                                   "thresholds": [
 
@@ -3021,7 +3021,7 @@ items:
                                   "decimals": 0,
                                   "link": true,
                                   "linkTooltip": "Drill down to pods",
-                                  "linkUrl": "/d/85a562078cdf77779eaa1add43ccec1e/k8s-resources-namespace?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$__cell_1",
+                                  "linkUrl": "./d/85a562078cdf77779eaa1add43ccec1e/k8s-resources-namespace?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$__cell_1",
                                   "pattern": "Value #A",
                                   "thresholds": [
 
@@ -3039,7 +3039,7 @@ items:
                                   "decimals": 0,
                                   "link": true,
                                   "linkTooltip": "Drill down to workloads",
-                                  "linkUrl": "/d/a87fb0d919ec0ea5f6543124e16c42a5/k8s-resources-workloads-namespace?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$__cell_1",
+                                  "linkUrl": "./d/a87fb0d919ec0ea5f6543124e16c42a5/k8s-resources-workloads-namespace?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$__cell_1",
                                   "pattern": "Value #B",
                                   "thresholds": [
 
@@ -3147,7 +3147,7 @@ items:
                                   "decimals": 2,
                                   "link": true,
                                   "linkTooltip": "Drill down to pods",
-                                  "linkUrl": "/d/85a562078cdf77779eaa1add43ccec1e/k8s-resources-namespace?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$__cell",
+                                  "linkUrl": "./d/85a562078cdf77779eaa1add43ccec1e/k8s-resources-namespace?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$__cell",
                                   "pattern": "namespace",
                                   "thresholds": [
 
@@ -3324,7 +3324,7 @@ items:
                       "options": [
 
                       ],
-                      "query": "label_values(node_cpu_seconds_total, cluster)",
+                      "query": "label_values(:kube_pod_info_node_count:, cluster)",
                       "refresh": 1,
                       "regex": "",
                       "sort": 2,
@@ -3639,7 +3639,7 @@ items:
                                   "decimals": 2,
                                   "link": true,
                                   "linkTooltip": "Drill down",
-                                  "linkUrl": "/d/6581e46e4e5c7ba40a07646395ef7b23/k8s-resources-pod?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$namespace&var-pod=$__cell",
+                                  "linkUrl": "./d/6581e46e4e5c7ba40a07646395ef7b23/k8s-resources-pod?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$namespace&var-pod=$__cell",
                                   "pattern": "pod",
                                   "thresholds": [
 
@@ -4058,7 +4058,7 @@ items:
                                   "decimals": 2,
                                   "link": true,
                                   "linkTooltip": "Drill down",
-                                  "linkUrl": "/d/6581e46e4e5c7ba40a07646395ef7b23/k8s-resources-pod?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$namespace&var-pod=$__cell",
+                                  "linkUrl": "./d/6581e46e4e5c7ba40a07646395ef7b23/k8s-resources-pod?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$namespace&var-pod=$__cell",
                                   "pattern": "pod",
                                   "thresholds": [
 
@@ -4244,7 +4244,7 @@ items:
                       "options": [
 
                       ],
-                      "query": "label_values(kube_pod_info, cluster)",
+                      "query": "label_values(:kube_pod_info_node_count:, cluster)",
                       "refresh": 1,
                       "regex": "",
                       "sort": 2,
@@ -5207,7 +5207,7 @@ items:
                       "options": [
 
                       ],
-                      "query": "label_values(kube_pod_info, cluster)",
+                      "query": "label_values(:kube_pod_info_node_count:, cluster)",
                       "refresh": 1,
                       "regex": "",
                       "sort": 2,
@@ -5576,7 +5576,7 @@ items:
                                   "decimals": 2,
                                   "link": true,
                                   "linkTooltip": "Drill down",
-                                  "linkUrl": "/d/6581e46e4e5c7ba40a07646395ef7b23/k8s-resources-pod?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$namespace&var-pod=$__cell",
+                                  "linkUrl": "./d/6581e46e4e5c7ba40a07646395ef7b23/k8s-resources-pod?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$namespace&var-pod=$__cell",
                                   "pattern": "pod",
                                   "thresholds": [
 
@@ -5941,7 +5941,7 @@ items:
                                   "decimals": 2,
                                   "link": true,
                                   "linkTooltip": "Drill down",
-                                  "linkUrl": "/d/6581e46e4e5c7ba40a07646395ef7b23/k8s-resources-pod?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$namespace&var-pod=$__cell",
+                                  "linkUrl": "./d/6581e46e4e5c7ba40a07646395ef7b23/k8s-resources-pod?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$namespace&var-pod=$__cell",
                                   "pattern": "pod",
                                   "thresholds": [
 
@@ -6100,7 +6100,7 @@ items:
                       "options": [
 
                       ],
-                      "query": "label_values(kube_pod_info, cluster)",
+                      "query": "label_values(:kube_pod_info_node_count:, cluster)",
                       "refresh": 1,
                       "regex": "",
                       "sort": 2,
@@ -6514,7 +6514,7 @@ items:
                                   "decimals": 2,
                                   "link": true,
                                   "linkTooltip": "Drill down",
-                                  "linkUrl": "/d/a164a7f0339f99e89cea5cb47e9be617/k8s-resources-workload?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$namespace&var-workload=$__cell&var-type=$__cell_2",
+                                  "linkUrl": "./d/a164a7f0339f99e89cea5cb47e9be617/k8s-resources-workload?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$namespace&var-workload=$__cell&var-type=$__cell_2",
                                   "pattern": "workload",
                                   "thresholds": [
 
@@ -6924,7 +6924,7 @@ items:
                                   "decimals": 2,
                                   "link": true,
                                   "linkTooltip": "Drill down",
-                                  "linkUrl": "/d/a164a7f0339f99e89cea5cb47e9be617/k8s-resources-workload?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$namespace&var-workload=$__cell&var-type=$__cell_2",
+                                  "linkUrl": "./d/a164a7f0339f99e89cea5cb47e9be617/k8s-resources-workload?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$namespace&var-workload=$__cell&var-type=$__cell_2",
                                   "pattern": "workload",
                                   "thresholds": [
 
@@ -7110,7 +7110,7 @@ items:
                       "options": [
 
                       ],
-                      "query": "label_values(kube_pod_info, cluster)",
+                      "query": "label_values(:kube_pod_info_node_count:, cluster)",
                       "refresh": 1,
                       "regex": "",
                       "sort": 2,


### PR DESCRIPTION
Grafana dashboard update from upstream + backport of local jsonnet dependency.
Follow-up of https://github.com/kubernetes-monitoring/kubernetes-mixin/pull/269