### PR TITLE
Bump prometheus-adapter and Grafana versions

### DIFF
--- a/jsonnet/kube-prometheus/kube-prometheus.libsonnet
+++ b/jsonnet/kube-prometheus/kube-prometheus.libsonnet
@@ -46,7 +46,7 @@ local configMapList = k3.core.v1.configMapList;
     namespace: 'default',
 
     versions+:: {
-      grafana: '6.2.2',
+      grafana: '6.4.3',
     },
 
     tlsCipherSuites: [

--- a/jsonnet/kube-prometheus/prometheus-adapter/prometheus-adapter.libsonnet
+++ b/jsonnet/kube-prometheus/prometheus-adapter/prometheus-adapter.libsonnet
@@ -5,7 +5,7 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
     namespace: 'default',
 
     versions+:: {
-      prometheusAdapter: 'v0.4.1',
+      prometheusAdapter: 'v0.5.0',
     },
 
     imageRepos+:: {

--- a/jsonnetfile.lock.json
+++ b/jsonnetfile.lock.json
@@ -57,7 +57,7 @@
                     "subdir": "grafana"
                 }
             },
-            "version": "567be6b15b7f3b747c48dc7b111c1860cab121c7"
+            "version": "539a90dbf63c812ad0194d8078dd776868a11c81"
         },
         {
             "name": "prometheus-operator",

--- a/kustomization.yaml
+++ b/kustomization.yaml
@@ -22,7 +22,6 @@ resources:
 - ./manifests/grafana-dashboardDefinitions.yaml
 - ./manifests/grafana-dashboardSources.yaml
 - ./manifests/grafana-deployment.yaml
-- ./manifests/grafana-rawDashboardDefinitions.yaml
 - ./manifests/grafana-service.yaml
 - ./manifests/grafana-serviceAccount.yaml
 - ./manifests/grafana-serviceMonitor.yaml

--- a/manifests/grafana-deployment.yaml
+++ b/manifests/grafana-deployment.yaml
@@ -16,7 +16,7 @@ spec:
         app: grafana
     spec:
       containers:
-      - image: grafana/grafana:6.2.2
+      - image: grafana/grafana:6.4.3
         name: grafana
         ports:
         - containerPort: 3000

--- a/manifests/prometheus-adapter-deployment.yaml
+++ b/manifests/prometheus-adapter-deployment.yaml
@@ -25,7 +25,7 @@ spec:
         - --metrics-relist-interval=1m
         - --prometheus-url=http://prometheus-k8s.monitoring.svc:9090/
         - --secure-port=6443
-        image: quay.io/coreos/k8s-prometheus-adapter-amd64:v0.4.1
+        image: quay.io/coreos/k8s-prometheus-adapter-amd64:v0.5.0
         name: prometheus-adapter
         ports:
         - containerPort: 6443


### PR DESCRIPTION
This brings (at least):

External metrics support (prometheus-adapter)
Elasticsearch as a source for logs (Grafana).

Fixes #267