### PR TITLE
Use configured resources for kube-rbac-proxy in node-exporter daemonset

### DIFF
--- a/jsonnet/kube-prometheus/node-exporter/node-exporter.libsonnet
+++ b/jsonnet/kube-prometheus/node-exporter/node-exporter.libsonnet
@@ -118,8 +118,8 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
         // forgo declaring the host port, however it is important to declare
         // it so that the scheduler can decide if the pod is schedulable.
         container.withPorts(containerPort.new($._config.nodeExporter.port) + containerPort.withHostPort($._config.nodeExporter.port) + containerPort.withName('https')) +
-        container.mixin.resources.withRequests({ cpu: '10m', memory: '20Mi' }) +
-        container.mixin.resources.withLimits({ cpu: '20m', memory: '60Mi' }) +
+        container.mixin.resources.withRequests($._config.resources['kube-rbac-proxy'].requests) +
+        container.mixin.resources.withLimits($._config.resources['kube-rbac-proxy'].limits) +
         container.withEnv([ip]);
 
       local c = [nodeExporter, proxy];

--- a/manifests/node-exporter-daemonset.yaml
+++ b/manifests/node-exporter-daemonset.yaml
@@ -61,7 +61,7 @@ spec:
         resources:
           limits:
             cpu: 20m
-            memory: 60Mi
+            memory: 40Mi
           requests:
             cpu: 10m
             memory: 20Mi


### PR DESCRIPTION
Since #132, `kube-rbac-proxy` resources can be configured in
`config.resources['kube-rbac-proxy']`, but the node-exporter daemonset
was still using hard-coded values.

This commit sets the request and limit resources to the configured
values for the `kube-rbac-proxy` container in the node-exporter pods.