### PR TITLE
prometheus: Let name and replicas be set in _config

### DIFF
--- a/jsonnet/kube-prometheus/prometheus/prometheus.libsonnet
+++ b/jsonnet/kube-prometheus/prometheus/prometheus.libsonnet
@@ -18,6 +18,8 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
     },
 
     prometheus+:: {
+      name: 'k8s',
+      replicas: 2,
       rules: {},
       namespaces: ['default', 'kube-system', $._config.namespace],
     },
@@ -26,10 +28,10 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
   prometheus+:: {
     local p = self,
 
-    name:: 'k8s',
+    name:: $._config.prometheus.name,
     namespace:: $._config.namespace,
     roleBindingNamespaces:: $._config.prometheus.namespaces,
-    replicas:: 2,
+    replicas:: $._config.prometheus.replicas,
     prometheusRules:: $._config.prometheus.rules,
     alertmanagerName:: $.alertmanager.service.metadata.name,
 


### PR DESCRIPTION
Before #260, the Prometheus name and number of replicas could be
configured in `_config.prometheus.name` and
`_config.prometheus.replicas` respectively.

It isn't the case anymore, which means that configurations that did set
a custom name for Prometheus will get a second Prometheus instance
called `k8s` when they upgrade kube-prometheus (see https://github.com/coreos/kube-prometheus/pull/260#issuecomment-544981316).

This commit adds back the ability to configure both of these parameters
in `_config`.