### PR TITLE
Makefile: Fix manifests target dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,9 +34,9 @@ generate: manifests **.md
 **.md: $(shell find examples) build.sh example.jsonnet
 	$(EMBEDMD_BINARY) -w `find . -name "*.md" | grep -v vendor`
 
-manifests: vendor example.jsonnet build.sh
+manifests: examples/kustomize.jsonnet vendor build.sh
 	rm -rf manifests
-	./build.sh ./examples/kustomize.jsonnet
+	./build.sh $<
 
 vendor: jsonnetfile.json jsonnetfile.lock.json
 	rm -rf vendor


### PR DESCRIPTION
Since 1664600, manifests are built using `examples/kustomize.jsonnet`
instead of `example.jsonnet`.

This commit updates the dependencies in the `manifests` target to
reflect that change.