### PR TITLE
Fix memory saturation dashboard

### DIFF
--- a/jsonnetfile.lock.json
+++ b/jsonnetfile.lock.json
@@ -97,7 +97,7 @@
                     "subdir": "docs/node-mixin"
                 }
             },
-            "version": "9f49fff79ef85fcebb69289622150e6d5346528b"
+            "version": "d574b4b41b72966a2ace4d6d81195081dfca8301"
         },
         {
             "name": "promgrafonnet",

--- a/manifests/grafana-dashboardDefinitions.yaml
+++ b/manifests/grafana-dashboardDefinitions.yaml
@@ -20553,7 +20553,7 @@ items:
                           "steppedLine": false,
                           "targets": [
                               {
-                                  "expr": "instance:node_memory_swap_io_pages:rate1m{job=\"node-exporter\"}",
+                                  "expr": "instance:node_vmstat_pgmajfault:rate1m{job=\"node-exporter\"}",
                                   "format": "time_series",
                                   "intervalFactor": 2,
                                   "legendFormat": "{{instance}}",
@@ -20566,7 +20566,7 @@ items:
                           ],
                           "timeFrom": null,
                           "timeShift": null,
-                          "title": "Memory Saturation (Swapped Pages)",
+                          "title": "Memory Saturation (Major Page Faults)",
                           "tooltip": {
                               "shared": false,
                               "sort": 0,
@@ -21501,10 +21501,10 @@ items:
                           "steppedLine": false,
                           "targets": [
                               {
-                                  "expr": "instance:node_memory_swap_io_pages:rate1m{job=\"node-exporter\", instance=\"$instance\"}",
+                                  "expr": "instance:node_vmstat_pgmajfault:rate1m{job=\"node-exporter\", instance=\"$instance\"}",
                                   "format": "time_series",
                                   "intervalFactor": 2,
-                                  "legendFormat": "Swap IO",
+                                  "legendFormat": "Major page faults",
                                   "legendLink": null,
                                   "step": 10
                               }
@@ -21514,7 +21514,7 @@ items:
                           ],
                           "timeFrom": null,
                           "timeShift": null,
-                          "title": "Memory Saturation (pages swapped per second)",
+                          "title": "Memory Saturation (Major Page Faults)",
                           "tooltip": {
                               "shared": false,
                               "sort": 0,

--- a/manifests/prometheus-rules.yaml
+++ b/manifests/prometheus-rules.yaml
@@ -37,12 +37,8 @@ spec:
         )
       record: instance:node_memory_utilisation:ratio
     - expr: |
-        (
-          rate(node_vmstat_pgpgin{job="node-exporter"}[1m])
-        +
-          rate(node_vmstat_pgpgout{job="node-exporter"}[1m])
-        )
-      record: instance:node_memory_swap_io_pages:rate1m
+        rate(node_vmstat_pgmajfault{job="node-exporter"}[1m])
+      record: instance:node_vmstat_pgmajfault:rate1m
     - expr: |
         rate(node_disk_io_time_seconds_total{job="node-exporter", device=~"nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+"}[1m])
       record: instance_device:node_disk_io_time_seconds:rate1m


### PR DESCRIPTION
Upgrade to prometheus/node_exporter@d574b4b, which includes a better
metric for memory saturation.

Fixes #222