### PR TITLE
Change node-exporter scrape interval to follow best practices

### DIFF
--- a/jsonnet/kube-prometheus/node-exporter/node-exporter.libsonnet
+++ b/jsonnet/kube-prometheus/node-exporter/node-exporter.libsonnet
@@ -168,7 +168,7 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
             {
               port: 'https',
               scheme: 'https',
-              interval: '30s',
+              interval: '15s',
               bearerTokenFile: '/var/run/secrets/kubernetes.io/serviceaccount/token',
               relabelings: [
                 {

--- a/jsonnetfile.lock.json
+++ b/jsonnetfile.lock.json
@@ -26,7 +26,7 @@
       "name": "grafana-builder",
       "source": {
         "git": {
-          "remote": "https://github.com/grafana/jsonnet-libs",
+          "remote": "https://github.com/kausalco/public",
           "subdir": "grafana-builder"
         }
       },

--- a/manifests/node-exporter-serviceMonitor.yaml
+++ b/manifests/node-exporter-serviceMonitor.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   endpoints:
   - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
-    interval: 30s
+    interval: 15s
     port: https
     relabelings:
     - action: replace


### PR DESCRIPTION
Different approach to problem from https://github.com/prometheus/node_exporter/pull/1557. With this, we should get more meaningful data and node-mixin recording rules should give better results.

/cc @bwplotka @brancz 