### PR TITLE
Enable discovery of Podmonitors across namespaces

### DIFF
--- a/jsonnet/kube-prometheus/prometheus/prometheus.libsonnet
+++ b/jsonnet/kube-prometheus/prometheus/prometheus.libsonnet
@@ -182,6 +182,7 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
           serviceMonitorSelector: {},
           podMonitorSelector: {},
           serviceMonitorNamespaceSelector: {},
+          podMonitorNamespaceSelector: {},
           nodeSelector: { 'kubernetes.io/os': 'linux' },
           ruleSelector: selector.withMatchLabels({
             role: 'alert-rules',

--- a/manifests/prometheus-prometheus.yaml
+++ b/manifests/prometheus-prometheus.yaml
@@ -14,6 +14,7 @@ spec:
   baseImage: quay.io/prometheus/prometheus
   nodeSelector:
     kubernetes.io/os: linux
+  podMonitorNamespaceSelector: {}
   podMonitorSelector: {}
   replicas: 2
   resources:


### PR DESCRIPTION
Currently, `podMonitorNamespaceSelector` directive is nil, which prevents Podmonitors to be discovered in namespaces other than `monitoring` (or kube-prom's defaut namespace).

This PRs makes default behavior identical to ServiceMonitor's.

Note: `kube-prometheus` is not pinned in current version of `jsonnetfile.json`, so I skipped the `jb update` part of the "Contributing" section.