### PR TITLE
Add node affinity for prometheus pod

### DIFF
--- a/jsonnet/kube-prometheus/kube-prometheus-node-affinity.libsonnet
+++ b/jsonnet/kube-prometheus/kube-prometheus-node-affinity.libsonnet
@@ -1,0 +1,29 @@
+local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
+local statefulSet = k.apps.v1.statefulSet;
+local nodeAffinity = statefulSet.mixin.spec.template.spec.affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecutionType;
+local matchExpression = nodeAffinity.mixin.preference.matchExpressionsType;
+
+{
+  local affinity(key) = {
+    affinity+: {
+      nodeAffinity: {
+        preferredDuringSchedulingIgnoredDuringExecution: [
+          nodeAffinity.new() + 
+          nodeAffinity.withWeight(100) +
+          nodeAffinity.mixin.preference.withMatchExpressions([
+            matchExpression.new() +
+            matchExpression.withKey(key) +
+            matchExpression.withOperator('Exists'), 
+          ]),
+        ],
+      },
+    },
+  },
+
+  prometheus+: {
+    prometheus+: {
+      spec+:
+        affinity('node-role.kubernetes.io/monitoring'),
+    },
+  },
+}


### PR DESCRIPTION
Sometimes prometheus pods needs to be scheduled to specific nodes

Signed-off-by: Benjamin <benjamin@yunify.com>