### PR TITLE
Make limits/requests resources of kube-state-metrics removable

### DIFF
--- a/jsonnet/kube-prometheus/kube-prometheus-strip-limits.libsonnet
+++ b/jsonnet/kube-prometheus/kube-prometheus-strip-limits.libsonnet
@@ -9,6 +9,9 @@
       'kube-rbac-proxy'+: {
         limits: {},
       },
+      'kube-state-metrics'+: {
+        limits: {},
+      },
       'node-exporter'+: {
         limits: {},
       },

--- a/jsonnet/kube-prometheus/kube-prometheus.libsonnet
+++ b/jsonnet/kube-prometheus/kube-prometheus.libsonnet
@@ -116,6 +116,10 @@ local configMapList = k3.core.v1.configMapList;
         requests: { cpu: '10m', memory: '20Mi' },
         limits: { cpu: '20m', memory: '40Mi' },
       },
+      'kube-state-metrics': {
+        requests: { cpu: '100m', memory: '150Mi' },
+        limits: { cpu: '100m', memory: '150Mi' },
+      },
       'node-exporter': {
         requests: { cpu: '102m', memory: '180Mi' },
         limits: { cpu: '250m', memory: '180Mi' },

--- a/jsonnet/kube-prometheus/kube-state-metrics/kube-state-metrics.libsonnet
+++ b/jsonnet/kube-prometheus/kube-state-metrics/kube-state-metrics.libsonnet
@@ -8,9 +8,6 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
       collectors: '',  // empty string gets a default set
       scrapeInterval: '30s',
       scrapeTimeout: '30s',
-
-      baseCPU: '100m',
-      baseMemory: '150Mi',
     },
 
     versions+:: {
@@ -174,8 +171,8 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
           '--telemetry-host=127.0.0.1',
           '--telemetry-port=8082',
         ] + if $._config.kubeStateMetrics.collectors != '' then ['--collectors=' + $._config.kubeStateMetrics.collectors] else []) +
-        container.mixin.resources.withRequests({ cpu: $._config.kubeStateMetrics.baseCPU, memory: $._config.kubeStateMetrics.baseMemory }) +
-        container.mixin.resources.withLimits({ cpu: $._config.kubeStateMetrics.baseCPU, memory: $._config.kubeStateMetrics.baseMemory });
+        container.mixin.resources.withRequests($._config.resources['kube-state-metrics'].requests) +
+        container.mixin.resources.withLimits($._config.resources['kube-state-metrics'].limits);
 
       local c = [proxyClusterMetrics, proxySelfMetrics, kubeStateMetrics];
 


### PR DESCRIPTION
Unify ways to override limits/requests with other containers