### PR TITLE
IPv6 compatibility

### DIFF
--- a/jsonnet/kube-prometheus/node-exporter/node-exporter.libsonnet
+++ b/jsonnet/kube-prometheus/node-exporter/node-exporter.libsonnet
@@ -105,7 +105,7 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
         container.new('kube-rbac-proxy', $._config.imageRepos.kubeRbacProxy + ':' + $._config.versions.kubeRbacProxy) +
         container.withArgs([
           '--logtostderr',
-          '--secure-listen-address=$(IP):' + $._config.nodeExporter.port,
+          '--secure-listen-address=$[(IP)]:' + $._config.nodeExporter.port,
           '--tls-cipher-suites=' + std.join(',', $._config.tlsCipherSuites),
           '--upstream=http://127.0.0.1:' + $._config.nodeExporter.port + '/',
         ]) +

--- a/manifests/node-exporter-daemonset.yaml
+++ b/manifests/node-exporter-daemonset.yaml
@@ -44,7 +44,7 @@ spec:
           readOnly: true
       - args:
         - --logtostderr
-        - --secure-listen-address=$(IP):9100
+        - --secure-listen-address=$[(IP)]:9100
         - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256
         - --upstream=http://127.0.0.1:9100/
         env:


### PR DESCRIPTION
Wrapping node-exporter pod listen address in square brackets to provide IPv6 compatibility. This is persisting IPv4 compatibility due to golang magic of handling IP addresses. 

/cc @brancz @s-urbaniak 