### PR TITLE
 jsonnet,manifests: Drop all metrics which are deprecated in kubernetes

### DIFF
--- a/jsonnet/kube-prometheus/dropping-deprecated-metrics-relabelings.libsonnet
+++ b/jsonnet/kube-prometheus/dropping-deprecated-metrics-relabelings.libsonnet
@@ -1,0 +1,50 @@
+[
+  // Drop all kubelet metrics which are deprecated in kubernetes.
+  {
+    sourceLabels: ['__name__'],
+    regex: 'kubelet_(pod_worker_latency_microseconds|pod_start_latency_microseconds|cgroup_manager_latency_microseconds|pod_worker_start_latency_microseconds|pleg_relist_latency_microseconds|pleg_relist_interval_microseconds|runtime_operations|runtime_operations_latency_microseconds|runtime_operations_errors|eviction_stats_age_microseconds|device_plugin_registration_count|device_plugin_alloc_latency_microseconds)',
+    action: 'drop',
+  },
+  // Drop all scheduler metrics which are deprecated in kubernetes.
+  {
+    sourceLabels: ['__name__'],
+    regex: 'scheduler_(e2e_scheduling_latency_microseconds|scheduling_algorithm_predicate_evaluation|scheduling_algorithm_priority_evaluation|scheduling_algorithm_preemption_evaluation|scheduling_algorithm_latency_microseconds|binding_latency_microseconds|scheduling_latency_seconds)',
+    action: 'drop',
+  },
+  // Drop all apiserver metrics which are deprecated in kubernetes.
+  {
+    sourceLabels: ['__name__'],
+    regex: 'apiserver_(request_count|request_latencies|request_latencies_summary|dropped_requests|storage_data_key_generation_latencies_microseconds|storage_transformation_failures_total|storage_transformation_latencies_microseconds|proxy_tunnel_sync_latency_secs)',
+    action: 'drop',
+  },
+  // Drop all docker metrics which are deprecated in kubernetes.
+  {
+    sourceLabels: ['__name__'],
+    regex: 'docker_(operations|operations_latency_microseconds|operations_errors|operations_timeout)',
+    action: 'drop',
+  },
+  // Drop all reflector metrics which are deprecated in kubernetes.
+  {
+    sourceLabels: ['__name__'],
+    regex: 'reflector_(items_per_list|items_per_watch|list_duration_seconds|lists_total|short_watches_total|watch_duration_seconds|watches_total)',
+    action: 'drop',
+  },
+  // Drop all etcd metrics which are deprecated in kubernetes.
+  {
+    sourceLabels: ['__name__'],
+    regex: 'etcd_(helper_cache_hit_count|helper_cache_miss_count|helper_cache_entry_count|request_cache_get_latencies_summary|request_cache_add_latencies_summary|request_latencies_summary)',
+    action: 'drop',
+  },
+  // Drop all transformation metrics which are deprecated in kubernetes.
+  {
+    sourceLabels: ['__name__'],
+    regex: 'transformation_(transformation_latencies_microseconds|failures_total)',
+    action: 'drop',
+  },
+  // Drop all other metrics which are deprecated in kubernetes.
+  {
+    sourceLabels: ['__name__'],
+    regex: 'network_plugin_operations_latency_microseconds|data_key_generation_latencies_microse|sync_proxy_rules_latency_microseconds|rest_client_request_latency_seconds',
+    action: 'drop',
+  },
+]

--- a/jsonnet/kube-prometheus/prometheus/prometheus.libsonnet
+++ b/jsonnet/kube-prometheus/prometheus/prometheus.libsonnet
@@ -160,6 +160,7 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
       local resourceRequirements = container.mixin.resourcesType;
       local selector = statefulSet.mixin.spec.selectorType;
 
+
       local resources =
         resourceRequirements.new() +
         resourceRequirements.withRequests({ memory: '400Mi' });
@@ -287,7 +288,7 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
               relabelings: [
                 {
                   sourceLabels: ['__metrics_path__'],
-                  targetLabel: 'metrics_path'
+                  targetLabel: 'metrics_path',
                 },
               ],
             },
@@ -304,10 +305,10 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
               relabelings: [
                 {
                   sourceLabels: ['__metrics_path__'],
-                  targetLabel: 'metrics_path'
+                  targetLabel: 'metrics_path',
                 },
               ],
-              metricRelabelings: [
+              metricRelabelings: (import 'kube-prometheus/dropping-deprecated-metrics-relabelings.libsonnet') + [
                 // Drop a bunch of metrics which are disabled but still sent, see
                 // https://github.com/google/cadvisor/issues/1925.
                 {
@@ -347,7 +348,7 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
             {
               port: 'http-metrics',
               interval: '30s',
-              metricRelabelings: [
+              metricRelabelings: (import 'kube-prometheus/dropping-deprecated-metrics-relabelings.libsonnet') + [
                 {
                   sourceLabels: ['__name__'],
                   regex: 'etcd_(debugging|disk|request|server).*',
@@ -402,7 +403,7 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
                 serverName: 'kubernetes',
               },
               bearerTokenFile: '/var/run/secrets/kubernetes.io/serviceaccount/token',
-              metricRelabelings: [
+              metricRelabelings: (import 'kube-prometheus/dropping-deprecated-metrics-relabelings.libsonnet') + [
                 {
                   sourceLabels: ['__name__'],
                   regex: 'etcd_(debugging|disk|request|server).*',

--- a/manifests/prometheus-serviceMonitorApiserver.yaml
+++ b/manifests/prometheus-serviceMonitorApiserver.yaml
@@ -11,6 +11,38 @@ spec:
     interval: 30s
     metricRelabelings:
     - action: drop
+      regex: kubelet_(pod_worker_latency_microseconds|pod_start_latency_microseconds|cgroup_manager_latency_microseconds|pod_worker_start_latency_microseconds|pleg_relist_latency_microseconds|pleg_relist_interval_microseconds|runtime_operations|runtime_operations_latency_microseconds|runtime_operations_errors|eviction_stats_age_microseconds|device_plugin_registration_count|device_plugin_alloc_latency_microseconds)
+      sourceLabels:
+      - __name__
+    - action: drop
+      regex: scheduler_(e2e_scheduling_latency_microseconds|scheduling_algorithm_predicate_evaluation|scheduling_algorithm_priority_evaluation|scheduling_algorithm_preemption_evaluation|scheduling_algorithm_latency_microseconds|binding_latency_microseconds|scheduling_latency_seconds)
+      sourceLabels:
+      - __name__
+    - action: drop
+      regex: apiserver_(request_count|request_latencies|request_latencies_summary|dropped_requests|storage_data_key_generation_latencies_microseconds|storage_transformation_failures_total|storage_transformation_latencies_microseconds|proxy_tunnel_sync_latency_secs)
+      sourceLabels:
+      - __name__
+    - action: drop
+      regex: docker_(operations|operations_latency_microseconds|operations_errors|operations_timeout)
+      sourceLabels:
+      - __name__
+    - action: drop
+      regex: reflector_(items_per_list|items_per_watch|list_duration_seconds|lists_total|short_watches_total|watch_duration_seconds|watches_total)
+      sourceLabels:
+      - __name__
+    - action: drop
+      regex: etcd_(helper_cache_hit_count|helper_cache_miss_count|helper_cache_entry_count|request_cache_get_latencies_summary|request_cache_add_latencies_summary|request_latencies_summary)
+      sourceLabels:
+      - __name__
+    - action: drop
+      regex: transformation_(transformation_latencies_microseconds|failures_total)
+      sourceLabels:
+      - __name__
+    - action: drop
+      regex: network_plugin_operations_latency_microseconds|data_key_generation_latencies_microse|sync_proxy_rules_latency_microseconds|rest_client_request_latency_seconds
+      sourceLabels:
+      - __name__
+    - action: drop
       regex: etcd_(debugging|disk|request|server).*
       sourceLabels:
       - __name__

--- a/manifests/prometheus-serviceMonitorKubeControllerManager.yaml
+++ b/manifests/prometheus-serviceMonitorKubeControllerManager.yaml
@@ -10,6 +10,38 @@ spec:
   - interval: 30s
     metricRelabelings:
     - action: drop
+      regex: kubelet_(pod_worker_latency_microseconds|pod_start_latency_microseconds|cgroup_manager_latency_microseconds|pod_worker_start_latency_microseconds|pleg_relist_latency_microseconds|pleg_relist_interval_microseconds|runtime_operations|runtime_operations_latency_microseconds|runtime_operations_errors|eviction_stats_age_microseconds|device_plugin_registration_count|device_plugin_alloc_latency_microseconds)
+      sourceLabels:
+      - __name__
+    - action: drop
+      regex: scheduler_(e2e_scheduling_latency_microseconds|scheduling_algorithm_predicate_evaluation|scheduling_algorithm_priority_evaluation|scheduling_algorithm_preemption_evaluation|scheduling_algorithm_latency_microseconds|binding_latency_microseconds|scheduling_latency_seconds)
+      sourceLabels:
+      - __name__
+    - action: drop
+      regex: apiserver_(request_count|request_latencies|request_latencies_summary|dropped_requests|storage_data_key_generation_latencies_microseconds|storage_transformation_failures_total|storage_transformation_latencies_microseconds|proxy_tunnel_sync_latency_secs)
+      sourceLabels:
+      - __name__
+    - action: drop
+      regex: docker_(operations|operations_latency_microseconds|operations_errors|operations_timeout)
+      sourceLabels:
+      - __name__
+    - action: drop
+      regex: reflector_(items_per_list|items_per_watch|list_duration_seconds|lists_total|short_watches_total|watch_duration_seconds|watches_total)
+      sourceLabels:
+      - __name__
+    - action: drop
+      regex: etcd_(helper_cache_hit_count|helper_cache_miss_count|helper_cache_entry_count|request_cache_get_latencies_summary|request_cache_add_latencies_summary|request_latencies_summary)
+      sourceLabels:
+      - __name__
+    - action: drop
+      regex: transformation_(transformation_latencies_microseconds|failures_total)
+      sourceLabels:
+      - __name__
+    - action: drop
+      regex: network_plugin_operations_latency_microseconds|data_key_generation_latencies_microse|sync_proxy_rules_latency_microseconds|rest_client_request_latency_seconds
+      sourceLabels:
+      - __name__
+    - action: drop
       regex: etcd_(debugging|disk|request|server).*
       sourceLabels:
       - __name__

--- a/manifests/prometheus-serviceMonitorKubelet.yaml
+++ b/manifests/prometheus-serviceMonitorKubelet.yaml
@@ -23,6 +23,38 @@ spec:
     interval: 30s
     metricRelabelings:
     - action: drop
+      regex: kubelet_(pod_worker_latency_microseconds|pod_start_latency_microseconds|cgroup_manager_latency_microseconds|pod_worker_start_latency_microseconds|pleg_relist_latency_microseconds|pleg_relist_interval_microseconds|runtime_operations|runtime_operations_latency_microseconds|runtime_operations_errors|eviction_stats_age_microseconds|device_plugin_registration_count|device_plugin_alloc_latency_microseconds)
+      sourceLabels:
+      - __name__
+    - action: drop
+      regex: scheduler_(e2e_scheduling_latency_microseconds|scheduling_algorithm_predicate_evaluation|scheduling_algorithm_priority_evaluation|scheduling_algorithm_preemption_evaluation|scheduling_algorithm_latency_microseconds|binding_latency_microseconds|scheduling_latency_seconds)
+      sourceLabels:
+      - __name__
+    - action: drop
+      regex: apiserver_(request_count|request_latencies|request_latencies_summary|dropped_requests|storage_data_key_generation_latencies_microseconds|storage_transformation_failures_total|storage_transformation_latencies_microseconds|proxy_tunnel_sync_latency_secs)
+      sourceLabels:
+      - __name__
+    - action: drop
+      regex: docker_(operations|operations_latency_microseconds|operations_errors|operations_timeout)
+      sourceLabels:
+      - __name__
+    - action: drop
+      regex: reflector_(items_per_list|items_per_watch|list_duration_seconds|lists_total|short_watches_total|watch_duration_seconds|watches_total)
+      sourceLabels:
+      - __name__
+    - action: drop
+      regex: etcd_(helper_cache_hit_count|helper_cache_miss_count|helper_cache_entry_count|request_cache_get_latencies_summary|request_cache_add_latencies_summary|request_latencies_summary)
+      sourceLabels:
+      - __name__
+    - action: drop
+      regex: transformation_(transformation_latencies_microseconds|failures_total)
+      sourceLabels:
+      - __name__
+    - action: drop
+      regex: network_plugin_operations_latency_microseconds|data_key_generation_latencies_microse|sync_proxy_rules_latency_microseconds|rest_client_request_latency_seconds
+      sourceLabels:
+      - __name__
+    - action: drop
       regex: container_(network_tcp_usage_total|network_udp_usage_total|tasks_state|cpu_load_average_10s)
       sourceLabels:
       - __name__


### PR DESCRIPTION
This PR drops all metrics that were deprecated in kubernetes versions 1.14 and 1.15. I went by the [chanelog](https://github.com/kubernetes/kubernetes/blob/0d58709016f3358f34a52c12087d707a64cc6cb0/CHANGELOG-1.17.md)/[s](https://github.com/kubernetes/kubernetes/blob/5e0f36705ef785a80955bd2b6412d9d227ff60da/CHANGELOG-1.14.md#removed-and-deprecated-metrics)

cc @brancz @s-urbaniak 