### PR TITLE
jsonnet/kube-prometheus: Adjust dropped deprecated metrics names

### DIFF
--- a/jsonnet/kube-prometheus/dropping-deprecated-metrics-relabelings.libsonnet
+++ b/jsonnet/kube-prometheus/dropping-deprecated-metrics-relabelings.libsonnet
@@ -2,7 +2,7 @@
   // Drop all kubelet metrics which are deprecated in kubernetes.
   {
     sourceLabels: ['__name__'],
-    regex: 'kubelet_(pod_worker_latency_microseconds|pod_start_latency_microseconds|cgroup_manager_latency_microseconds|pod_worker_start_latency_microseconds|pleg_relist_latency_microseconds|pleg_relist_interval_microseconds|runtime_operations|runtime_operations_latency_microseconds|runtime_operations_errors|eviction_stats_age_microseconds|device_plugin_registration_count|device_plugin_alloc_latency_microseconds)',
+    regex: 'kubelet_(pod_worker_latency_microseconds|pod_start_latency_microseconds|cgroup_manager_latency_microseconds|pod_worker_start_latency_microseconds|pleg_relist_latency_microseconds|pleg_relist_interval_microseconds|runtime_operations|runtime_operations_latency_microseconds|runtime_operations_errors|eviction_stats_age_microseconds|device_plugin_registration_count|device_plugin_alloc_latency_microseconds|network_plugin_operations_latency_microseconds)',
     action: 'drop',
   },
   // Drop all scheduler metrics which are deprecated in kubernetes.
@@ -44,7 +44,7 @@
   // Drop all other metrics which are deprecated in kubernetes.
   {
     sourceLabels: ['__name__'],
-    regex: 'network_plugin_operations_latency_microseconds|data_key_generation_latencies_microse|sync_proxy_rules_latency_microseconds|rest_client_request_latency_seconds',
+    regex: 'kubeproxy_sync_proxy_rules_latency_microseconds|rest_client_request_latency_secons',
     action: 'drop',
   },
 ]

--- a/manifests/prometheus-serviceMonitorApiserver.yaml
+++ b/manifests/prometheus-serviceMonitorApiserver.yaml
@@ -11,7 +11,7 @@ spec:
     interval: 30s
     metricRelabelings:
     - action: drop
-      regex: kubelet_(pod_worker_latency_microseconds|pod_start_latency_microseconds|cgroup_manager_latency_microseconds|pod_worker_start_latency_microseconds|pleg_relist_latency_microseconds|pleg_relist_interval_microseconds|runtime_operations|runtime_operations_latency_microseconds|runtime_operations_errors|eviction_stats_age_microseconds|device_plugin_registration_count|device_plugin_alloc_latency_microseconds)
+      regex: kubelet_(pod_worker_latency_microseconds|pod_start_latency_microseconds|cgroup_manager_latency_microseconds|pod_worker_start_latency_microseconds|pleg_relist_latency_microseconds|pleg_relist_interval_microseconds|runtime_operations|runtime_operations_latency_microseconds|runtime_operations_errors|eviction_stats_age_microseconds|device_plugin_registration_count|device_plugin_alloc_latency_microseconds|network_plugin_operations_latency_microseconds)
       sourceLabels:
       - __name__
     - action: drop
@@ -39,7 +39,7 @@ spec:
       sourceLabels:
       - __name__
     - action: drop
-      regex: network_plugin_operations_latency_microseconds|data_key_generation_latencies_microse|sync_proxy_rules_latency_microseconds|rest_client_request_latency_seconds
+      regex: kubeproxy_sync_proxy_rules_latency_microseconds|rest_client_request_latency_secons
       sourceLabels:
       - __name__
     - action: drop

--- a/manifests/prometheus-serviceMonitorKubeControllerManager.yaml
+++ b/manifests/prometheus-serviceMonitorKubeControllerManager.yaml
@@ -10,7 +10,7 @@ spec:
   - interval: 30s
     metricRelabelings:
     - action: drop
-      regex: kubelet_(pod_worker_latency_microseconds|pod_start_latency_microseconds|cgroup_manager_latency_microseconds|pod_worker_start_latency_microseconds|pleg_relist_latency_microseconds|pleg_relist_interval_microseconds|runtime_operations|runtime_operations_latency_microseconds|runtime_operations_errors|eviction_stats_age_microseconds|device_plugin_registration_count|device_plugin_alloc_latency_microseconds)
+      regex: kubelet_(pod_worker_latency_microseconds|pod_start_latency_microseconds|cgroup_manager_latency_microseconds|pod_worker_start_latency_microseconds|pleg_relist_latency_microseconds|pleg_relist_interval_microseconds|runtime_operations|runtime_operations_latency_microseconds|runtime_operations_errors|eviction_stats_age_microseconds|device_plugin_registration_count|device_plugin_alloc_latency_microseconds|network_plugin_operations_latency_microseconds)
       sourceLabels:
       - __name__
     - action: drop
@@ -38,7 +38,7 @@ spec:
       sourceLabels:
       - __name__
     - action: drop
-      regex: network_plugin_operations_latency_microseconds|data_key_generation_latencies_microse|sync_proxy_rules_latency_microseconds|rest_client_request_latency_seconds
+      regex: kubeproxy_sync_proxy_rules_latency_microseconds|rest_client_request_latency_secons
       sourceLabels:
       - __name__
     - action: drop

--- a/manifests/prometheus-serviceMonitorKubelet.yaml
+++ b/manifests/prometheus-serviceMonitorKubelet.yaml
@@ -23,7 +23,7 @@ spec:
     interval: 30s
     metricRelabelings:
     - action: drop
-      regex: kubelet_(pod_worker_latency_microseconds|pod_start_latency_microseconds|cgroup_manager_latency_microseconds|pod_worker_start_latency_microseconds|pleg_relist_latency_microseconds|pleg_relist_interval_microseconds|runtime_operations|runtime_operations_latency_microseconds|runtime_operations_errors|eviction_stats_age_microseconds|device_plugin_registration_count|device_plugin_alloc_latency_microseconds)
+      regex: kubelet_(pod_worker_latency_microseconds|pod_start_latency_microseconds|cgroup_manager_latency_microseconds|pod_worker_start_latency_microseconds|pleg_relist_latency_microseconds|pleg_relist_interval_microseconds|runtime_operations|runtime_operations_latency_microseconds|runtime_operations_errors|eviction_stats_age_microseconds|device_plugin_registration_count|device_plugin_alloc_latency_microseconds|network_plugin_operations_latency_microseconds)
       sourceLabels:
       - __name__
     - action: drop
@@ -51,7 +51,7 @@ spec:
       sourceLabels:
       - __name__
     - action: drop
-      regex: network_plugin_operations_latency_microseconds|data_key_generation_latencies_microse|sync_proxy_rules_latency_microseconds|rest_client_request_latency_seconds
+      regex: kubeproxy_sync_proxy_rules_latency_microseconds|rest_client_request_latency_secons
       sourceLabels:
       - __name__
     - action: drop


### PR DESCRIPTION
The names were not complete in the kubernetes CHANGELOG. I manually checked these against a running cluster to make sure this is the full name of the metric. In the CHANGELOG it was lacking the prefix. 🤷‍♀ 

cc @brancz @s-urbaniak 