### PR TITLE
fix coredns monitoring on EKS

### DIFF
--- a/jsonnet/kube-prometheus/kube-prometheus-eks.libsonnet
+++ b/jsonnet/kube-prometheus/kube-prometheus-eks.libsonnet
@@ -4,6 +4,17 @@ local servicePort = k.core.v1.service.mixin.spec.portsType;
 
 {
   prometheus+: {
+    serviceMonitorCoreDNS+: {
+        spec+: {
+          endpoints: [
+            {
+              bearerTokenFile: "/var/run/secrets/kubernetes.io/serviceaccount/token",
+              interval: "15s",
+              targetPort: 9153
+            }
+          ]
+        },
+      },
     AwsEksCniMetricService:
         service.new('aws-node', { 'k8s-app' : 'aws-node' } , servicePort.newNamed('cni-metrics-port', 61678, 61678)) +
         service.mixin.metadata.withNamespace('kube-system') +


### PR DESCRIPTION
On EKS, CoreDNS does not have service endpoint with the name `metrics`. Using `targetPort` instead solved the issue and allow Prometheus to discover core DNS.