### PR TITLE
jsonnet/kube-prometheus/kube-state-metrics: Add missing clusterRole permissions

### DIFF
--- a/jsonnet/kube-prometheus/kube-state-metrics/kube-state-metrics.libsonnet
+++ b/jsonnet/kube-prometheus/kube-state-metrics/kube-state-metrics.libsonnet
@@ -122,6 +122,22 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
         rulesType.withApiGroups(['storage.k8s.io']) +
         rulesType.withResources([
           'storageclasses',
+          'volumeattachments',
+        ]) +
+        rulesType.withVerbs(['list', 'watch']),
+
+        rulesType.new() +
+        rulesType.withApiGroups(['admissionregistration.k8s.io']) +
+        rulesType.withResources([
+          'validatingwebhookconfigurations',
+          'mutatingwebhookconfigurations',
+        ]) +
+        rulesType.withVerbs(['list', 'watch']),
+
+        rulesType.new() +
+        rulesType.withApiGroups(['networking.k8s.io']) +
+        rulesType.withResources([
+          'networkpolicies',
         ]) +
         rulesType.withVerbs(['list', 'watch']),
       ];

--- a/manifests/kube-state-metrics-clusterRole.yaml
+++ b/manifests/kube-state-metrics-clusterRole.yaml
@@ -86,6 +86,22 @@ rules:
   - storage.k8s.io
   resources:
   - storageclasses
+  - volumeattachments
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - validatingwebhookconfigurations
+  - mutatingwebhookconfigurations
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
   verbs:
   - list
   - watch


### PR DESCRIPTION
kube-state-metrics was recently updated to version to 1.9.0 and requires some new clusterRole permissions:

```
- apiGroups:
  - admissionregistration.k8s.io
  resources:
  - validatingwebhookconfigurations
  - mutatingwebhookconfigurations
  verbs:
  - list
  - watch

- apiGroups:
  - networking.k8s.io
  resources:
  - networkpolicies
  verbs:
  - list
  - watch

- apiGroups:
  - storage.k8s.io
  resources:
  - volumeattachments
  verbs:
  - list
  - watch
```