### PR TITLE
bump kube-state-metrics to version 1.9.2

### DIFF
--- a/jsonnet/kube-prometheus/kube-state-metrics/kube-state-metrics.libsonnet
+++ b/jsonnet/kube-prometheus/kube-state-metrics/kube-state-metrics.libsonnet
@@ -11,7 +11,7 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
     },
 
     versions+:: {
-      kubeStateMetrics: 'v1.9.1',
+      kubeStateMetrics: 'v1.9.2',
       kubeRbacProxy: 'v0.4.1',
     },
 

--- a/manifests/kube-state-metrics-deployment.yaml
+++ b/manifests/kube-state-metrics-deployment.yaml
@@ -55,7 +55,7 @@ spec:
         - --port=8081
         - --telemetry-host=127.0.0.1
         - --telemetry-port=8082
-        image: quay.io/coreos/kube-state-metrics:v1.9.1
+        image: quay.io/coreos/kube-state-metrics:v1.9.2
         name: kube-state-metrics
         resources:
           limits:


### PR DESCRIPTION
Bump **kube-state-metrics** to latest version (**1.9.2**)
