### PR TITLE
prometheus-adapter: add nodes resource to aggregated-metrics-reader

### DIFF
--- a/jsonnet/kube-prometheus/prometheus-adapter/prometheus-adapter.libsonnet
+++ b/jsonnet/kube-prometheus/prometheus-adapter/prometheus-adapter.libsonnet
@@ -191,7 +191,7 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
       local rules =
         policyRule.new() +
         policyRule.withApiGroups(['metrics.k8s.io']) +
-        policyRule.withResources(['pods']) +
+        policyRule.withResources(['pods', 'nodes']) +
         policyRule.withVerbs(['get','list','watch']);
 
       clusterRole.new() +

--- a/manifests/prometheus-adapter-clusterRoleAggregatedMetricsReader.yaml
+++ b/manifests/prometheus-adapter-clusterRoleAggregatedMetricsReader.yaml
@@ -11,6 +11,7 @@ rules:
   - metrics.k8s.io
   resources:
   - pods
+  - nodes
   verbs:
   - get
   - list


### PR DESCRIPTION
This effectively backports https://github.com/kubernetes-sigs/metrics-server/pull/297 here. We also need it to fix https://bugzilla.redhat.com/show_bug.cgi?id=1723662.