### PR TITLE
*: Throw away unused high cardinality apiserver duration buckets

### DIFF
--- a/jsonnet/kube-prometheus/prometheus/prometheus.libsonnet
+++ b/jsonnet/kube-prometheus/prometheus/prometheus.libsonnet
@@ -420,6 +420,11 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
                   regex: 'apiserver_admission_step_admission_latencies_seconds_.*',
                   action: 'drop',
                 },
+                {
+                  sourceLabels: ['__name__', 'le'],
+                  regex: 'apiserver_request_duration_seconds_bucket;(0.15|0.25|0.3|0.35|0.4|0.45|0.6|0.7|0.8|0.9|1.25|1.5|1.75|2.5|3|3.5|4.5|6|7|8|9|15|25|30|50)',
+                  action: 'drop',
+                },
               ],
             },
           ],

--- a/manifests/prometheus-serviceMonitorApiserver.yaml
+++ b/manifests/prometheus-serviceMonitorApiserver.yaml
@@ -54,6 +54,11 @@ spec:
       regex: apiserver_admission_step_admission_latencies_seconds_.*
       sourceLabels:
       - __name__
+    - action: drop
+      regex: apiserver_request_duration_seconds_bucket;(0.15|0.25|0.3|0.35|0.4|0.45|0.6|0.7|0.8|0.9|1.25|1.5|1.75|2.5|3|3.5|4.5|6|7|8|9|15|25|30|50)
+      sourceLabels:
+      - __name__
+      - le
     port: https
     scheme: https
     tlsConfig:


### PR DESCRIPTION
Before: 
![before_count](https://user-images.githubusercontent.com/4546722/72984447-055c6300-3de4-11ea-99cb-79f2655213d6.png)
![before_bucket](https://user-images.githubusercontent.com/4546722/72984448-055c6300-3de4-11ea-8d31-8b0862dbc0b9.png)

After:
![after_count](https://user-images.githubusercontent.com/4546722/72984462-0b524400-3de4-11ea-8b55-0ea5f081bebd.png)
![after_bucket](https://user-images.githubusercontent.com/4546722/72984466-0b524400-3de4-11ea-96fc-6eddec2ec509.png)

This shouldn't have any effect on our alerts or dashboards as the buckets are cumulative and for those purposes the remaining buckets should be sufficient.

tl;dr this cuts the apiserver duration histogram (our highest cardinality metric) by 65%.

@LiliC @s-urbaniak @krasi-georgiev 