### PR TITLE
KubeNodeUnreachable fires after 2 minutes now

### DIFF
--- a/manifests/prometheus-rules.yaml
+++ b/manifests/prometheus-rules.yaml
@@ -1043,6 +1043,7 @@ spec:
         runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubenodeunreachable
       expr: |
         kube_node_spec_taint{job="kube-state-metrics",key="node.kubernetes.io/unreachable",effect="NoSchedule"} == 1
+      for: 2m
       labels:
         severity: warning
     - alert: KubeletTooManyPods


### PR DESCRIPTION
I propose this change because we are using the Kubernetes Cluster Autoscaler and whenever the autoscaler terminates nodes, for a brief amount of time the alert `KubeNodeUnreachable` is firing. I think this could solve it, but any feedback is appreciated.

Does anyone else have this problem with this alert? Maybe something is wrong in our EKS 1.14 cluster.

What do you think?