### PR TITLE
*: Add default receivers

### DIFF
--- a/jsonnet/kube-prometheus/alertmanager/alertmanager.libsonnet
+++ b/jsonnet/kube-prometheus/alertmanager/alertmanager.libsonnet
@@ -40,19 +40,31 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
           group_wait: '30s',
           group_interval: '5m',
           repeat_interval: '12h',
-          receiver: 'null',
+          receiver: 'Default',
           routes: [
             {
-              receiver: 'null',
+              receiver: 'Watchdog',
               match: {
                 alertname: 'Watchdog',
+              },
+            },
+            {
+              receiver: 'Critical',
+              match: {
+                severity: 'critical',
               },
             },
           ],
         },
         receivers: [
           {
-            name: 'null',
+            name: 'Default',
+          },
+          {
+            name: 'Watchdog',
+          },
+          {
+            name: 'Critical',
           },
         ],
       },

--- a/jsonnetfile.json
+++ b/jsonnetfile.json
@@ -1,6 +1,7 @@
 {
   "dependencies": [
     {
+      "name": "kube-prometheus",
       "source": {
         "local": {
           "directory": "jsonnet/kube-prometheus"
@@ -8,6 +9,5 @@
       },
       "version": ""
     }
-  ],
-  "legacyImports": true
+  ]
 }

--- a/jsonnetfile.lock.json
+++ b/jsonnetfile.lock.json
@@ -1,6 +1,18 @@
 {
   "dependencies": [
     {
+      "name": "etcd-mixin",
+      "source": {
+        "git": {
+          "remote": "https://github.com/coreos/etcd",
+          "subdir": "Documentation/etcd-mixin"
+        }
+      },
+      "version": "53f15caf73b9285d6043009fa64c925d5a8f573c",
+      "sum": "Ko3qhNfC2vN/houLh6C0Ryacjv70gl0DVPGU/PQ4OD0="
+    },
+    {
+      "name": "grafana",
       "source": {
         "git": {
           "remote": "https://github.com/brancz/kubernetes-grafana",
@@ -11,36 +23,7 @@
       "sum": "b8faWX1qqLGyN67sA36oRqYZ5HX+tHBRMPtrWRqIysE="
     },
     {
-      "source": {
-        "git": {
-          "remote": "https://github.com/coreos/etcd",
-          "subdir": "Documentation/etcd-mixin"
-        }
-      },
-      "version": "798c073b894a41a5296ef0266923fa54f61c36ae",
-      "sum": "Ko3qhNfC2vN/houLh6C0Ryacjv70gl0DVPGU/PQ4OD0="
-    },
-    {
-      "source": {
-        "git": {
-          "remote": "https://github.com/coreos/prometheus-operator",
-          "subdir": "jsonnet/prometheus-operator"
-        }
-      },
-      "version": "8d44e0990230144177f97cf62ae4f43b1c4e3168",
-      "sum": "5U7/8MD3pF9O0YDTtUhg4vctkUBRVFxZxWUyhtNiBM8="
-    },
-    {
-      "source": {
-        "git": {
-          "remote": "https://github.com/grafana/grafonnet-lib",
-          "subdir": "grafonnet"
-        }
-      },
-      "version": "f3ee1d810858cf556d25f045b53cb0f1fd10b94e",
-      "sum": "14YBZUP/cl8qi9u86xiuUS4eXQrEAam+4GSg6i9n9Ys="
-    },
-    {
+      "name": "grafana-builder",
       "source": {
         "git": {
           "remote": "https://github.com/grafana/jsonnet-libs",
@@ -51,6 +34,18 @@
       "sum": "slxrtftVDiTlQK22ertdfrg4Epnq97gdrLI63ftUfaE="
     },
     {
+      "name": "grafonnet",
+      "source": {
+        "git": {
+          "remote": "https://github.com/grafana/grafonnet-lib",
+          "subdir": "grafonnet"
+        }
+      },
+      "version": "c459106d2d2b583dd3a83f6c75eb52abee3af764",
+      "sum": "CeM3LRgUCUJTolTdMnerfMPGYmhClx7gX5ajrQVEY2Y="
+    },
+    {
+      "name": "ksonnet",
       "source": {
         "git": {
           "remote": "https://github.com/ksonnet/ksonnet-lib",
@@ -58,10 +53,19 @@
         }
       },
       "version": "0d2f82676817bbf9e4acf6495b2090205f323b9f",
-      "sum": "h28BXZ7+vczxYJ2sCt8JuR9+yznRtU/iA6DCpQUrtEg=",
-      "name": "ksonnet"
+      "sum": "h28BXZ7+vczxYJ2sCt8JuR9+yznRtU/iA6DCpQUrtEg="
     },
     {
+      "name": "kube-prometheus",
+      "source": {
+        "local": {
+          "directory": "jsonnet/kube-prometheus"
+        }
+      },
+      "version": ""
+    },
+    {
+      "name": "kubernetes-mixin",
       "source": {
         "git": {
           "remote": "https://github.com/kubernetes-monitoring/kubernetes-mixin",
@@ -72,6 +76,40 @@
       "sum": "rMy/F8MHwyKuyud73q9vY8PrX6BEODTU9ela03iv9UY="
     },
     {
+      "name": "node-mixin",
+      "source": {
+        "git": {
+          "remote": "https://github.com/prometheus/node_exporter",
+          "subdir": "docs/node-mixin"
+        }
+      },
+      "version": "9bb37873a8757508853b14e6048a9c3418f3d667",
+      "sum": "7vEamDTP9AApeiF4Zu9ZyXzDIs3rYHzwf9k7g8X+wsg="
+    },
+    {
+      "name": "prometheus",
+      "source": {
+        "git": {
+          "remote": "https://github.com/prometheus/prometheus",
+          "subdir": "documentation/prometheus-mixin"
+        }
+      },
+      "version": "ddd49b743c1c03527064d38f4830258b4a6ccb27",
+      "sum": "u1YS9CVuBTcw2vks0PZbLb1gtlI/7bVGDVBZsjWFLTw="
+    },
+    {
+      "name": "prometheus-operator",
+      "source": {
+        "git": {
+          "remote": "https://github.com/coreos/prometheus-operator",
+          "subdir": "jsonnet/prometheus-operator"
+        }
+      },
+      "version": "8d44e0990230144177f97cf62ae4f43b1c4e3168",
+      "sum": "5U7/8MD3pF9O0YDTtUhg4vctkUBRVFxZxWUyhtNiBM8="
+    },
+    {
+      "name": "promgrafonnet",
       "source": {
         "git": {
           "remote": "https://github.com/kubernetes-monitoring/kubernetes-mixin",
@@ -82,6 +120,7 @@
       "sum": "VhgBM39yv0f4bKv8VfGg4FXkg573evGDRalip9ypKbc="
     },
     {
+      "name": "slo-libsonnet",
       "source": {
         "git": {
           "remote": "https://github.com/metalmatze/slo-libsonnet",
@@ -90,36 +129,6 @@
       },
       "version": "437c402c5f3ad86c3c16db8471f1649284fef0ee",
       "sum": "2Zcyku1f558VrUpMaJnI78fahDksPLcS1idmxxwcQ7Q="
-    },
-    {
-      "source": {
-        "git": {
-          "remote": "https://github.com/prometheus/node_exporter",
-          "subdir": "docs/node-mixin"
-        }
-      },
-      "version": "04ad4b351058bc89e83702d149f2961efa989bf4",
-      "sum": "7vEamDTP9AApeiF4Zu9ZyXzDIs3rYHzwf9k7g8X+wsg="
-    },
-    {
-      "source": {
-        "git": {
-          "remote": "https://github.com/prometheus/prometheus",
-          "subdir": "documentation/prometheus-mixin"
-        }
-      },
-      "version": "ddd49b743c1c03527064d38f4830258b4a6ccb27",
-      "sum": "u1YS9CVuBTcw2vks0PZbLb1gtlI/7bVGDVBZsjWFLTw=",
-      "name": "prometheus"
-    },
-    {
-      "source": {
-        "local": {
-          "directory": "jsonnet/kube-prometheus"
-        }
-      },
-      "version": ""
     }
-  ],
-  "legacyImports": false
+  ]
 }

--- a/manifests/alertmanager-secret.yaml
+++ b/manifests/alertmanager-secret.yaml
@@ -22,16 +22,21 @@ stringData:
       "target_match_re":
         "severity": "info"
     "receivers":
-    - "name": "null"
+    - "name": "Default"
+    - "name": "Watchdog"
+    - "name": "Critical"
     "route":
       "group_by":
       - "namespace"
       "group_interval": "5m"
       "group_wait": "30s"
-      "receiver": "null"
+      "receiver": "Default"
       "repeat_interval": "12h"
       "routes":
       - "match":
           "alertname": "Watchdog"
-        "receiver": "null"
+        "receiver": "Watchdog"
+      - "match":
+          "severity": "critical"
+        "receiver": "Critical"
 type: Opaque


### PR DESCRIPTION
This patch adds a few out of the box receivers that only need their
notification provider configuration filled in, instead of figuring out
all the wiring for critical alerts for example.

@s-urbaniak @paulfantom 