### PR TITLE
[backport] jsonnet: add general rules for up/down targets

### DIFF
--- a/jsonnet/kube-prometheus/rules/general.libsonnet
+++ b/jsonnet/kube-prometheus/rules/general.libsonnet
@@ -1,0 +1,19 @@
+{
+  prometheusRules+:: {
+    groups+: [
+      {
+        name: 'kube-prometheus-general.rules',
+        rules: [
+          {
+            expr: 'count without(instance, pod, node) (up == 1)',
+            record: 'count:up1',
+          },
+          {
+            expr: 'count without(instance, pod, node) (up == 0)',
+            record: 'count:up0',
+          },
+        ],
+      },
+    ],
+  },
+}

--- a/jsonnet/kube-prometheus/rules/rules.libsonnet
+++ b/jsonnet/kube-prometheus/rules/rules.libsonnet
@@ -1,1 +1,2 @@
-(import 'node-rules.libsonnet')
+(import 'node-rules.libsonnet') +
+(import 'general.libsonnet')

--- a/manifests/prometheus-rules.yaml
+++ b/manifests/prometheus-rules.yaml
@@ -265,6 +265,12 @@ spec:
     - expr: cluster:node_cpu_seconds_total:rate5m / count(sum(node_cpu_seconds_total)
         BY (instance, cpu))
       record: cluster:node_cpu:ratio
+  - name: kube-prometheus-general.rules
+    rules:
+    - expr: count without(instance, pod, node) (up == 1)
+      record: count:up1
+    - expr: count without(instance, pod, node) (up == 0)
+      record: count:up0
   - name: node-exporter
     rules:
     - alert: NodeFilesystemSpaceFillingUp


### PR DESCRIPTION
This is a backport of https://github.com/coreos/kube-prometheus/pull/397 into 0.4

/cc @coreos/team-monitoring 