### PR TITLE
Remove preserveUnknownField CRD setting

### DIFF
--- a/jsonnet/kube-prometheus/kube-prometheus.libsonnet
+++ b/jsonnet/kube-prometheus/kube-prometheus.libsonnet
@@ -17,6 +17,34 @@ local configMapList = k3.core.v1.configMapList;
   kubePrometheus+:: {
     namespace: k.core.v1.namespace.new($._config.namespace),
   },
+  prometheusOperator+::
+  {
+    '0alertmanagerCustomResourceDefinition'+: {
+      spec: std.mergePatch(super.spec, {
+        preserveUnknownFields: null,
+      }),
+    },
+    '0prometheusCustomResourceDefinition'+: {
+      spec: std.mergePatch(super.spec, {
+        preserveUnknownFields: null,
+      }),
+    },
+    '0servicemonitorCustomResourceDefinition'+: {
+      spec: std.mergePatch(super.spec, {
+        preserveUnknownFields: null,
+      }),
+    },
+    '0podmonitorCustomResourceDefinition'+: {
+      spec: std.mergePatch(super.spec, {
+        preserveUnknownFields: null,
+      }),
+    },
+    '0prometheusruleCustomResourceDefinition'+: {
+      spec: std.mergePatch(super.spec, {
+        preserveUnknownFields: null,
+      }),
+    },
+  },
   grafana+:: {
     dashboardDefinitions: configMapList.new(super.dashboardDefinitions),
     serviceMonitor: {

--- a/manifests/setup/prometheus-operator-0alertmanagerCustomResourceDefinition.yaml
+++ b/manifests/setup/prometheus-operator-0alertmanagerCustomResourceDefinition.yaml
@@ -12,7 +12,6 @@ spec:
     listKind: AlertmanagerList
     plural: alertmanagers
     singular: alertmanager
-  preserveUnknownFields: false
   scope: Namespaced
   validation:
     openAPIV3Schema:

--- a/manifests/setup/prometheus-operator-0podmonitorCustomResourceDefinition.yaml
+++ b/manifests/setup/prometheus-operator-0podmonitorCustomResourceDefinition.yaml
@@ -12,7 +12,6 @@ spec:
     listKind: PodMonitorList
     plural: podmonitors
     singular: podmonitor
-  preserveUnknownFields: false
   scope: Namespaced
   validation:
     openAPIV3Schema:

--- a/manifests/setup/prometheus-operator-0prometheusCustomResourceDefinition.yaml
+++ b/manifests/setup/prometheus-operator-0prometheusCustomResourceDefinition.yaml
@@ -12,7 +12,6 @@ spec:
     listKind: PrometheusList
     plural: prometheuses
     singular: prometheus
-  preserveUnknownFields: false
   scope: Namespaced
   validation:
     openAPIV3Schema:

--- a/manifests/setup/prometheus-operator-0prometheusruleCustomResourceDefinition.yaml
+++ b/manifests/setup/prometheus-operator-0prometheusruleCustomResourceDefinition.yaml
@@ -12,7 +12,6 @@ spec:
     listKind: PrometheusRuleList
     plural: prometheusrules
     singular: prometheusrule
-  preserveUnknownFields: false
   scope: Namespaced
   validation:
     openAPIV3Schema:

--- a/manifests/setup/prometheus-operator-0servicemonitorCustomResourceDefinition.yaml
+++ b/manifests/setup/prometheus-operator-0servicemonitorCustomResourceDefinition.yaml
@@ -12,7 +12,6 @@ spec:
     listKind: ServiceMonitorList
     plural: servicemonitors
     singular: servicemonitor
-  preserveUnknownFields: false
   scope: Namespaced
   validation:
     openAPIV3Schema:


### PR DESCRIPTION
This allows the CRDs to be generated to maintain compatibility with
Kubernetes 1.14 and earlier versions.

Helps to mitigate https://github.com/coreos/prometheus-operator/issues/2924