### PR TITLE
jsonnet/kube-prometheus: Add back kube-rbac-proxy containers to

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,4 +63,4 @@ test-in-docker:
 .PHONY: generate generate-in-docker test test-in-docker fmt
 
 $(JB_BINARY):
-	go get github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb
+	go get github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb@v0.2.0

--- a/jsonnet/kube-prometheus/kube-rbac-proxy/container.libsonnet
+++ b/jsonnet/kube-prometheus/kube-rbac-proxy/container.libsonnet
@@ -1,0 +1,90 @@
+local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
+local deployment = k.apps.v1.deployment;
+local container = deployment.mixin.spec.template.spec.containersType;
+local containerPort = container.portsType;
+
+{
+  local krp = self,
+  config+:: {
+    kubeRbacProxy: {
+      image: error 'must provide image',
+      name: error 'must provide name',
+      securePortName: error 'must provide securePortName',
+      securePort: error 'must provide securePort',
+      secureListenAddress: error 'must provide secureListenAddress',
+      upstream: error 'must provide upstream',
+      tlsCipherSuites: error 'must provide tlsCipherSuites',
+    },
+  },
+
+  specMixin:: {
+    local sm = self,
+    config+:: {
+      kubeRbacProxy: {
+        image: error 'must provide image',
+        name: error 'must provide name',
+        securePortName: error 'must provide securePortName',
+        securePort: error 'must provide securePort',
+        secureListenAddress: error 'must provide secureListenAddress',
+        upstream: error 'must provide upstream',
+        tlsCipherSuites: error 'must provide tlsCipherSuites',
+      },
+    },
+    spec+: {
+      template+: {
+        spec+: {
+          containers+: [
+            container.new(krp.config.kubeRbacProxy.name, krp.config.kubeRbacProxy.image) +
+            container.withArgs([
+              '--logtostderr',
+              '--secure-listen-address=' + krp.config.kubeRbacProxy.secureListenAddress,
+              '--tls-cipher-suites=' + std.join(',', krp.config.kubeRbacProxy.tlsCipherSuites),
+              '--upstream=' + krp.config.kubeRbacProxy.upstream,
+            ]) +
+            container.withPorts(containerPort.newNamed(krp.config.kubeRbacProxy.securePort, krp.config.kubeRbacProxy.securePortName)),
+          ],
+        },
+      },
+    },
+  },
+
+  deploymentMixin:: {
+    local dm = self,
+    config+:: {
+      kubeRbacProxy: {
+        image: error 'must provide image',
+        name: error 'must provide name',
+        securePortName: error 'must provide securePortName',
+        securePort: error 'must provide securePort',
+        secureListenAddress: error 'must provide secureListenAddress',
+        upstream: error 'must provide upstream',
+        tlsCipherSuites: error 'must provide tlsCipherSuites',
+      },
+    },
+    deployment+: krp.specMixin {
+      config+:: {
+        kubeRbacProxy+: dm.config.kubeRbacProxy,
+      },
+    },
+  },
+
+  statefulSetMixin:: {
+    local sm = self,
+    config+:: {
+      kubeRbacProxy: {
+        image: error 'must provide image',
+        name: error 'must provide name',
+        securePortName: error 'must provide securePortName',
+        securePort: error 'must provide securePort',
+        secureListenAddress: error 'must provide secureListenAddress',
+        upstream: error 'must provide upstream',
+        tlsCipherSuites: error 'must provide tlsCipherSuites',
+      },
+    },
+    statefulSet+: krp.specMixin {
+      config+:: {
+        kubeRbacProxy+: sm.config.kubeRbacProxy,
+      },
+    },
+  },
+}

--- a/jsonnet/kube-prometheus/kube-state-metrics/kube-state-metrics.libsonnet
+++ b/jsonnet/kube-prometheus/kube-state-metrics/kube-state-metrics.libsonnet
@@ -1,4 +1,10 @@
 {
+  _config+:: {
+    kubeStateMetrics+:: {
+      scrapeInterval: '30s',
+      scrapeTimeout: '30s',
+    },
+  },
   kubeStateMetrics+:: (import 'kube-state-metrics/kube-state-metrics.libsonnet') +
                       {
                         local ksm = self,
@@ -6,38 +12,110 @@
                         namespace:: 'monitoring',
                         version:: '1.9.4',  //$._config.versions.kubeStateMetrics,
                         image:: 'quay.io/coreos/kube-state-metrics:v' + ksm.version,
-                        serviceMonitor: {
-                          apiVersion: 'monitoring.coreos.com/v1',
-                          kind: 'ServiceMonitor',
-                          metadata: {
-                            name: ksm.name,
-                            namespace: ksm.namespace,
-                            labels: ksm.commonLabels,
-                          },
-                          spec: {
-                            jobLabel: 'app.kubernetes.io/name',
-                            selector: {
-                              matchLabels: ksm.commonLabels,
-                            },
-                            endpoints: [
+                        service+: {
+                          spec+: {
+                            ports: [
                               {
-                                port: 'http-metrics',
-                                interval: '30s',
-                                scrapeTimeout: '30s',
-                                honorLabels: true,
-                                relabelings: [
-                                  {
-                                    regex: '(pod|service|endpoint|namespace)',
-                                    action: 'labeldrop',
-                                  },
-                                ],
+                                name: 'https-main',
+                                port: 8443,
+                                targetPort: 'https-main',
                               },
                               {
-                                port: 'telemetry',
-                                interval: '30s',
+                                name: 'https-self',
+                                port: 9443,
+                                targetPort: 'https-self',
                               },
                             ],
                           },
                         },
-                      },
+                        deployment+: {
+                          spec+: {
+                            template+: {
+                              spec+: {
+                                containers: std.map(function(c) c {
+                                  ports: null,
+                                  args: ['--host=127.0.0.1', '--port=8081', '--telemetry-host=127.0.0.1', '--telemetry-port=8082'],
+                                }, super.containers),
+                              },
+                            },
+                          },
+                        },
+                        serviceMonitor:
+                          {
+                            apiVersion: 'monitoring.coreos.com/v1',
+                            kind: 'ServiceMonitor',
+                            metadata: {
+                              name: 'kube-state-metrics',
+                              namespace: $._config.namespace,
+                              labels: {
+                                'app.kubernetes.io/name': 'kube-state-metrics',
+                                'app.kubernetes.io/version': ksm.version,
+                              },
+                            },
+                            spec: {
+                              jobLabel: 'app.kubernetes.io/name',
+                              selector: {
+                                matchLabels: {
+                                  'app.kubernetes.io/name': 'kube-state-metrics',
+                                },
+                              },
+                              endpoints: [
+                                {
+                                  port: 'https-main',
+                                  scheme: 'https',
+                                  interval: $._config.kubeStateMetrics.scrapeInterval,
+                                  scrapeTimeout: $._config.kubeStateMetrics.scrapeTimeout,
+                                  honorLabels: true,
+                                  bearerTokenFile: '/var/run/secrets/kubernetes.io/serviceaccount/token',
+                                  relabelings: [
+                                    {
+                                      regex: '(pod|service|endpoint|namespace)',
+                                      action: 'labeldrop',
+                                    },
+                                  ],
+                                  tlsConfig: {
+                                    insecureSkipVerify: true,
+                                  },
+                                },
+                                {
+                                  port: 'https-self',
+                                  scheme: 'https',
+                                  interval: $._config.kubeStateMetrics.scrapeInterval,
+                                  bearerTokenFile: '/var/run/secrets/kubernetes.io/serviceaccount/token',
+                                  tlsConfig: {
+                                    insecureSkipVerify: true,
+                                  },
+                                },
+                              ],
+                            },
+                          },
+                      } +
+                      ((import 'kube-prometheus/kube-rbac-proxy/container.libsonnet') {
+                         config+:: {
+                           kubeRbacProxy: {
+                             local cfg = self,
+                             image: $._config.imageRepos.kubeRbacProxy + ':' + $._config.versions.kubeRbacProxy,
+                             name: 'kube-rbac-proxy-main',
+                             securePortName: 'https-main',
+                             securePort: 8443,
+                             secureListenAddress: ':%d' % self.securePort,
+                             upstream: 'http://127.0.0.1:8081/',
+                             tlsCipherSuites: $._config.tlsCipherSuites,
+                           },
+                         },
+                       }).deploymentMixin +
+                      ((import 'kube-prometheus/kube-rbac-proxy/container.libsonnet') {
+                         config+:: {
+                           kubeRbacProxy: {
+                             local cfg = self,
+                             image: $._config.imageRepos.kubeRbacProxy + ':' + $._config.versions.kubeRbacProxy,
+                             name: 'kube-rbac-proxy-self',
+                             securePortName: 'https-self',
+                             securePort: 9443,
+                             secureListenAddress: ':%d' % self.securePort,
+                             upstream: 'http://127.0.0.1:8082/',
+                             tlsCipherSuites: $._config.tlsCipherSuites,
+                           },
+                         },
+                       }).deploymentMixin,
 }

--- a/manifests/kube-state-metrics-deployment.yaml
+++ b/manifests/kube-state-metrics-deployment.yaml
@@ -18,7 +18,12 @@ spec:
         app.kubernetes.io/version: v1.9.4
     spec:
       containers:
-      - image: quay.io/coreos/kube-state-metrics:v1.9.4
+      - args:
+        - --host=127.0.0.1
+        - --port=8081
+        - --telemetry-host=127.0.0.1
+        - --telemetry-port=8082
+        image: quay.io/coreos/kube-state-metrics:v1.9.4
         livenessProbe:
           httpGet:
             path: /healthz
@@ -26,11 +31,7 @@ spec:
           initialDelaySeconds: 5
           timeoutSeconds: 5
         name: kube-state-metrics
-        ports:
-        - containerPort: 8080
-          name: http-metrics
-        - containerPort: 8081
-          name: telemetry
+        ports: null
         readinessProbe:
           httpGet:
             path: /
@@ -39,6 +40,26 @@ spec:
           timeoutSeconds: 5
         securityContext:
           runAsUser: 65534
+      - args:
+        - --logtostderr
+        - --secure-listen-address=:8443
+        - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256
+        - --upstream=http://127.0.0.1:8081/
+        image: quay.io/coreos/kube-rbac-proxy:v0.4.1
+        name: kube-rbac-proxy-main
+        ports:
+        - containerPort: 8443
+          name: https-main
+      - args:
+        - --logtostderr
+        - --secure-listen-address=:9443
+        - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256
+        - --upstream=http://127.0.0.1:8082/
+        image: quay.io/coreos/kube-rbac-proxy:v0.4.1
+        name: kube-rbac-proxy-self
+        ports:
+        - containerPort: 9443
+          name: https-self
       nodeSelector:
         kubernetes.io/os: linux
       serviceAccountName: kube-state-metrics

--- a/manifests/kube-state-metrics-service.yaml
+++ b/manifests/kube-state-metrics-service.yaml
@@ -9,11 +9,11 @@ metadata:
 spec:
   clusterIP: None
   ports:
-  - name: http-metrics
-    port: 8080
-    targetPort: http-metrics
-  - name: telemetry
-    port: 8081
-    targetPort: telemetry
+  - name: https-main
+    port: 8443
+    targetPort: https-main
+  - name: https-self
+    port: 9443
+    targetPort: https-self
   selector:
     app.kubernetes.io/name: kube-state-metrics

--- a/manifests/kube-state-metrics-serviceMonitor.yaml
+++ b/manifests/kube-state-metrics-serviceMonitor.yaml
@@ -3,22 +3,29 @@ kind: ServiceMonitor
 metadata:
   labels:
     app.kubernetes.io/name: kube-state-metrics
-    app.kubernetes.io/version: v1.9.4
+    app.kubernetes.io/version: 1.9.4
   name: kube-state-metrics
   namespace: monitoring
 spec:
   endpoints:
-  - honorLabels: true
+  - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    honorLabels: true
     interval: 30s
-    port: http-metrics
+    port: https-main
     relabelings:
     - action: labeldrop
       regex: (pod|service|endpoint|namespace)
+    scheme: https
     scrapeTimeout: 30s
-  - interval: 30s
-    port: telemetry
+    tlsConfig:
+      insecureSkipVerify: true
+  - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    interval: 30s
+    port: https-self
+    scheme: https
+    tlsConfig:
+      insecureSkipVerify: true
   jobLabel: app.kubernetes.io/name
   selector:
     matchLabels:
       app.kubernetes.io/name: kube-state-metrics
-      app.kubernetes.io/version: v1.9.4


### PR DESCRIPTION
kube-state-metrics. These were removed by accident when migrating to
using upstream libsonnet.

Still need to test it out. But ready for review. @coreos/team-monitoring 