### PR TITLE
Makefile: lock jsonnet-bundler version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,4 +63,4 @@ test-in-docker:
 .PHONY: generate generate-in-docker test test-in-docker fmt
 
 $(JB_BINARY):
-	go get github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb
+	go get github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb@v0.2.0


### PR DESCRIPTION
The new version (v0.3.1) of jsonnet bundler causes some changes
to go.mod and jsonnetfile.json.  The build should 'go get' a
specific version instead of the latest to prevent new releases
from breaking existing builds.

This should fix the CI failures currently seen on #428 and #429 