### PR TITLE
Adjust the threshold of the NodeFilesystemSpaceFillingUp alert from the node-exporter mixin

### DIFF
--- a/jsonnet/kube-prometheus/kube-prometheus.libsonnet
+++ b/jsonnet/kube-prometheus/kube-prometheus.libsonnet
@@ -116,6 +116,7 @@ local configMapList = k3.core.v1.configMapList;
     kubeletSelector: 'job="kubelet", metrics_path="/metrics"',
     kubeStateMetricsSelector: 'job="kube-state-metrics"',
     nodeExporterSelector: 'job="node-exporter"',
+    fsSpaceFillingUpCriticalThreshold: 15,
     notKubeDnsSelector: 'job!="kube-dns"',
     kubeSchedulerSelector: 'job="kube-scheduler"',
     kubeControllerManagerSelector: 'job="kube-controller-manager"',

--- a/jsonnetfile.lock.json
+++ b/jsonnetfile.lock.json
@@ -105,8 +105,8 @@
           "subdir": "docs/node-mixin"
         }
       },
-      "version": "92ea3c6a3f0ea2d1d55de168e65037e2313f9940",
-      "sum": "7vEamDTP9AApeiF4Zu9ZyXzDIs3rYHzwf9k7g8X+wsg="
+      "version": "0107bc794204f50d887898da60032da890637471",
+      "sum": "VKdF0zPMSCiuIuXWblSz2VOeBaXzQ7fp40vz9sxj+Bo="
     },
     {
       "name": "prometheus",

--- a/manifests/prometheus-rules.yaml
+++ b/manifests/prometheus-rules.yaml
@@ -330,7 +330,7 @@ spec:
         summary: Filesystem is predicted to run out of space within the next 4 hours.
       expr: |
         (
-          node_filesystem_avail_bytes{job="node-exporter",fstype!=""} / node_filesystem_size_bytes{job="node-exporter",fstype!=""} * 100 < 20
+          node_filesystem_avail_bytes{job="node-exporter",fstype!=""} / node_filesystem_size_bytes{job="node-exporter",fstype!=""} * 100 < 15
         and
           predict_linear(node_filesystem_avail_bytes{job="node-exporter",fstype!=""}[6h], 4*60*60) < 0
         and


### PR DESCRIPTION
Reduce threshold of the node-exporter alert to 15% space available, instead of 20% (default).

As per https://github.com/coreos/kube-prometheus/issues/294