### PR TITLE
jsonnet/kube-prometheus/kube-state-metrics: Remove probes

### DIFF
--- a/jsonnet/kube-prometheus/kube-state-metrics/kube-state-metrics.libsonnet
+++ b/jsonnet/kube-prometheus/kube-state-metrics/kube-state-metrics.libsonnet
@@ -33,7 +33,9 @@
                             template+: {
                               spec+: {
                                 containers: std.map(function(c) c {
-                                  ports: null,
+                                  ports:: null,
+                                  livenessProbe:: null,
+                                  readinessProbe:: null,
                                   args: ['--host=127.0.0.1', '--port=8081', '--telemetry-host=127.0.0.1', '--telemetry-port=8082'],
                                 }, super.containers),
                               },

--- a/manifests/kube-state-metrics-deployment.yaml
+++ b/manifests/kube-state-metrics-deployment.yaml
@@ -24,20 +24,7 @@ spec:
         - --telemetry-host=127.0.0.1
         - --telemetry-port=8082
         image: quay.io/coreos/kube-state-metrics:v1.9.5
-        livenessProbe:
-          httpGet:
-            path: /healthz
-            port: 8080
-          initialDelaySeconds: 5
-          timeoutSeconds: 5
         name: kube-state-metrics
-        ports: null
-        readinessProbe:
-          httpGet:
-            path: /
-            port: 8081
-          initialDelaySeconds: 5
-          timeoutSeconds: 5
         securityContext:
           runAsUser: 65534
       - args:


### PR DESCRIPTION
cc @coreos/team-monitoring @dgrisonnet 

Still want to test for longer, but ready for review. Is there another way other then doing null in jsonnet to remove it? @brancz @metalmatze 