### PR TITLE
fix invalid Usage section reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,7 +278,7 @@ Once updated, just follow the instructions under "Compiling" and "Apply the kube
 
 ## Configuration
 
-Jsonnet has the concept of hidden fields. These are fields, that are not going to be rendered in a result. This is used to configure the kube-prometheus components in jsonnet. In the example jsonnet code of the above [Usage section](#Usage), you can see an example of this, where the `namespace` is being configured to be `monitoring`. In order to not override the whole object, use the `+::` construct of jsonnet, to merge objects, this way you can override individual settings, but retain all other settings and defaults.
+Jsonnet has the concept of hidden fields. These are fields, that are not going to be rendered in a result. This is used to configure the kube-prometheus components in jsonnet. In the example jsonnet code of the above [Customizing Kube-Prometheus section](#customizing-kube-prometheus), you can see an example of this, where the `namespace` is being configured to be `monitoring`. In order to not override the whole object, use the `+::` construct of jsonnet, to merge objects, this way you can override individual settings, but retain all other settings and defaults.
 
 These are the available fields with their respective default values:
 ```


### PR DESCRIPTION
Replace Usage section reference to Customizing Kube-Prometheus section.

Usage section was removed from the README.md file in [this](https://github.com/coreos/kube-prometheus/commit/e8e0b639f7098116f558422d40a0433d851d6e20) commit. But the reference to the section was not modified.