### PR TITLE
Ignore KubeletTooManyPods on Fargate nodes

### DIFF
--- a/jsonnet/kube-prometheus/kube-prometheus.libsonnet
+++ b/jsonnet/kube-prometheus/kube-prometheus.libsonnet
@@ -113,7 +113,7 @@ local configMapList = k3.core.v1.configMapList;
     ],
 
     cadvisorSelector: 'job="kubelet", metrics_path="/metrics/cadvisor"',
-    kubeletSelector: 'job="kubelet", metrics_path="/metrics"',
+    kubeletSelector: 'job="kubelet", metrics_path="/metrics, node!~"^fargate-.*""',
     kubeStateMetricsSelector: 'job="kube-state-metrics"',
     nodeExporterSelector: 'job="node-exporter"',
     fsSpaceFillingUpCriticalThreshold: 15,


### PR DESCRIPTION
Ignore KubeletTooManyPods on fargate nodes as it's its normal behavior.
This replaces #447.