### PR TITLE
Use irate for CPU measurements

### DIFF
--- a/jsonnet/kube-prometheus/prometheus-adapter/prometheus-adapter.libsonnet
+++ b/jsonnet/kube-prometheus/prometheus-adapter/prometheus-adapter.libsonnet
@@ -19,8 +19,8 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
       config: |||
         resourceRules:
           cpu:
-            containerQuery: sum(rate(container_cpu_usage_seconds_total{<<.LabelMatchers>>,container!="POD",container!="",pod!=""}[5m])) by (<<.GroupBy>>)
-            nodeQuery: sum(1 - rate(node_cpu_seconds_total{mode="idle"}[5m]) * on(namespace, pod) group_left(node) node_namespace_pod:kube_pod_info:{<<.LabelMatchers>>}) by (<<.GroupBy>>)
+            containerQuery: sum(irate(container_cpu_usage_seconds_total{<<.LabelMatchers>>,container!="POD",container!="",pod!=""}[5m])) by (<<.GroupBy>>)
+            nodeQuery: sum(1 - irate(node_cpu_seconds_total{mode="idle"}[5m]) * on(namespace, pod) group_left(node) node_namespace_pod:kube_pod_info:{<<.LabelMatchers>>}) by (<<.GroupBy>>)
             resources:
               overrides:
                 node:

--- a/manifests/prometheus-adapter-configMap.yaml
+++ b/manifests/prometheus-adapter-configMap.yaml
@@ -3,8 +3,8 @@ data:
   config.yaml: |
     resourceRules:
       cpu:
-        containerQuery: sum(rate(container_cpu_usage_seconds_total{<<.LabelMatchers>>,container!="POD",container!="",pod!=""}[5m])) by (<<.GroupBy>>)
-        nodeQuery: sum(1 - rate(node_cpu_seconds_total{mode="idle"}[5m]) * on(namespace, pod) group_left(node) node_namespace_pod:kube_pod_info:{<<.LabelMatchers>>}) by (<<.GroupBy>>)
+        containerQuery: sum(irate(container_cpu_usage_seconds_total{<<.LabelMatchers>>,container!="POD",container!="",pod!=""}[5m])) by (<<.GroupBy>>)
+        nodeQuery: sum(1 - irate(node_cpu_seconds_total{mode="idle"}[5m]) * on(namespace, pod) group_left(node) node_namespace_pod:kube_pod_info:{<<.LabelMatchers>>}) by (<<.GroupBy>>)
         resources:
           overrides:
             node:


### PR DESCRIPTION
Currently, examples show to use `rate()` for `nodeQuery`. This causes the "flattening" of resource consumption as we get values affected by the past, causing a quite bad UX for people used to having `top` and `kubectl top` quite similar in functionality. The issue can be easily solved by swapping `rate()` to `irate()`.

I am proposing this only for CPU and not for memory as the former is usually a faster changing and can have more benefits from using `irate`.

More on the differences between `rate()` and `irate()` can be found in https://www.robustperception.io/irate-graphs-are-better-graphs

Related https://bugzilla.redhat.com/show_bug.cgi?id=1812004 

/cc @brancz @s-urbaniak