### PR TITLE
Add version and image source as config parameters on kube-state-metrics

### DIFF
--- a/docs/EKS-cni-support.md
+++ b/docs/EKS-cni-support.md
@@ -7,8 +7,8 @@ One fatal issue that can occur is that you run out of IP addresses in your eks c
 You can monitor the `awscni` using kube-promethus with : 
 [embedmd]:# (../examples/eks-cni-example.jsonnet)
 ```jsonnet
-local kp =  (import 'kube-prometheus/kube-prometheus.libsonnet') +
-            (import 'kube-prometheus/kube-prometheus-eks.libsonnet') + {
+local kp = (import 'kube-prometheus/kube-prometheus.libsonnet') +
+           (import 'kube-prometheus/kube-prometheus-eks.libsonnet') + {
   _config+:: {
     namespace: 'monitoring',
   },
@@ -32,7 +32,7 @@ local kp =  (import 'kube-prometheus/kube-prometheus.libsonnet') +
 { ['node-exporter-' + name]: kp.nodeExporter[name] for name in std.objectFields(kp.nodeExporter) } +
 { ['kube-state-metrics-' + name]: kp.kubeStateMetrics[name] for name in std.objectFields(kp.kubeStateMetrics) } +
 { ['prometheus-' + name]: kp.prometheus[name] for name in std.objectFields(kp.prometheus) } +
-{ ['prometheus-adapter-' + name]: kp.prometheusAdapter[name] for name in std.objectFields(kp.prometheusAdapter) } 
+{ ['prometheus-adapter-' + name]: kp.prometheusAdapter[name] for name in std.objectFields(kp.prometheusAdapter) }
 ```
 
 After you have the required yaml file please run

--- a/docs/weave-net-support.md
+++ b/docs/weave-net-support.md
@@ -17,8 +17,8 @@ Using kube-prometheus and kubectl you will be able install the following for mon
 
 [embedmd]:# (../examples/weave-net-example.jsonnet)
 ```jsonnet
-local kp =  (import 'kube-prometheus/kube-prometheus.libsonnet') +
-            (import 'kube-prometheus/kube-prometheus-weave-net.libsonnet') + {
+local kp = (import 'kube-prometheus/kube-prometheus.libsonnet') +
+           (import 'kube-prometheus/kube-prometheus-weave-net.libsonnet') + {
   _config+:: {
     namespace: 'monitoring',
   },
@@ -27,25 +27,26 @@ local kp =  (import 'kube-prometheus/kube-prometheus.libsonnet') +
       function(group)
         if group.name == 'weave-net' then
           group {
-            rules: std.map(function(rule)
-              if rule.alert == "WeaveNetFastDPFlowsLow" then
-                rule {
-                  expr: "sum(weave_flows) < 20000"
-                }
-              else if rule.alert == "WeaveNetIPAMUnreachable" then
-                rule {
-                  expr: "weave_ipam_unreachable_percentage > 25"
-                }
-              else
-                rule
+            rules: std.map(
+              function(rule)
+                if rule.alert == 'WeaveNetFastDPFlowsLow' then
+                  rule {
+                    expr: 'sum(weave_flows) < 20000',
+                  }
+                else if rule.alert == 'WeaveNetIPAMUnreachable' then
+                  rule {
+                    expr: 'weave_ipam_unreachable_percentage > 25',
+                  }
+                else
+                  rule
               ,
               group.rules
-            )
+            ),
           }
         else
           group,
-        super.groups
-      ),
+      super.groups
+    ),
   },
 };
 

--- a/examples/eks-cni-example.jsonnet
+++ b/examples/eks-cni-example.jsonnet
@@ -1,5 +1,5 @@
-local kp =  (import 'kube-prometheus/kube-prometheus.libsonnet') +
-            (import 'kube-prometheus/kube-prometheus-eks.libsonnet') + {
+local kp = (import 'kube-prometheus/kube-prometheus.libsonnet') +
+           (import 'kube-prometheus/kube-prometheus-eks.libsonnet') + {
   _config+:: {
     namespace: 'monitoring',
   },
@@ -23,4 +23,4 @@ local kp =  (import 'kube-prometheus/kube-prometheus.libsonnet') +
 { ['node-exporter-' + name]: kp.nodeExporter[name] for name in std.objectFields(kp.nodeExporter) } +
 { ['kube-state-metrics-' + name]: kp.kubeStateMetrics[name] for name in std.objectFields(kp.kubeStateMetrics) } +
 { ['prometheus-' + name]: kp.prometheus[name] for name in std.objectFields(kp.prometheus) } +
-{ ['prometheus-adapter-' + name]: kp.prometheusAdapter[name] for name in std.objectFields(kp.prometheusAdapter) } 
+{ ['prometheus-adapter-' + name]: kp.prometheusAdapter[name] for name in std.objectFields(kp.prometheusAdapter) }

--- a/examples/weave-net-example.jsonnet
+++ b/examples/weave-net-example.jsonnet
@@ -1,5 +1,5 @@
-local kp =  (import 'kube-prometheus/kube-prometheus.libsonnet') +
-            (import 'kube-prometheus/kube-prometheus-weave-net.libsonnet') + {
+local kp = (import 'kube-prometheus/kube-prometheus.libsonnet') +
+           (import 'kube-prometheus/kube-prometheus-weave-net.libsonnet') + {
   _config+:: {
     namespace: 'monitoring',
   },
@@ -8,25 +8,26 @@ local kp =  (import 'kube-prometheus/kube-prometheus.libsonnet') +
       function(group)
         if group.name == 'weave-net' then
           group {
-            rules: std.map(function(rule)
-              if rule.alert == "WeaveNetFastDPFlowsLow" then
-                rule {
-                  expr: "sum(weave_flows) < 20000"
-                }
-              else if rule.alert == "WeaveNetIPAMUnreachable" then
-                rule {
-                  expr: "weave_ipam_unreachable_percentage > 25"
-                }
-              else
-                rule
+            rules: std.map(
+              function(rule)
+                if rule.alert == 'WeaveNetFastDPFlowsLow' then
+                  rule {
+                    expr: 'sum(weave_flows) < 20000',
+                  }
+                else if rule.alert == 'WeaveNetIPAMUnreachable' then
+                  rule {
+                    expr: 'weave_ipam_unreachable_percentage > 25',
+                  }
+                else
+                  rule
               ,
               group.rules
-            )
+            ),
           }
         else
           group,
-        super.groups
-      ),
+      super.groups
+    ),
   },
 };
 

--- a/go.sum
+++ b/go.sum
@@ -7,6 +7,7 @@ github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuy
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d h1:UQZhZ2O0vMHr2cI+DC1Mbh0TJxzA3RcLoMsFw+aXw7E=
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
+github.com/campoy/embedmd v1.0.0 h1:V4kI2qTJJLf4J29RzI/MAt2c3Bl4dQSYPuflzwFH2hY=
 github.com/campoy/embedmd v1.0.0/go.mod h1:oxyr9RCiSXg0M3VJ3ks0UGfp98BpSSGr0kpiX3MzVl8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/jsonnet/kube-prometheus/kube-state-metrics/kube-state-metrics.libsonnet
+++ b/jsonnet/kube-prometheus/kube-state-metrics/kube-state-metrics.libsonnet
@@ -1,5 +1,11 @@
 {
   _config+:: {
+    versions+:: {
+      kubeStateMetrics: '1.9.5',
+    },
+    imageRepos+:: {
+      kubeStateMetrics: 'quay.io/coreos/kube-state-metrics',
+    },
     kubeStateMetrics+:: {
       scrapeInterval: '30s',
       scrapeTimeout: '30s',
@@ -10,8 +16,8 @@
                         local ksm = self,
                         name:: 'kube-state-metrics',
                         namespace:: 'monitoring',
-                        version:: '1.9.5',  //$._config.versions.kubeStateMetrics,
-                        image:: 'quay.io/coreos/kube-state-metrics:v' + ksm.version,
+                        version:: $._config.versions.kubeStateMetrics,
+                        image:: $._config.imageRepos.kubeStateMetrics + ':v' + $._config.versions.kubeStateMetrics,
                         service+: {
                           spec+: {
                             ports: [


### PR DESCRIPTION
This PR adds Kube-state-metrics image and version as configuration parameters allowing them to be overrode.

Fixes #455.