### PR TITLE
Fix kube-state-metrics namespace override

### DIFF
--- a/jsonnet/kube-prometheus/kube-state-metrics/kube-state-metrics.libsonnet
+++ b/jsonnet/kube-prometheus/kube-state-metrics/kube-state-metrics.libsonnet
@@ -15,7 +15,7 @@
                       {
                         local ksm = self,
                         name:: 'kube-state-metrics',
-                        namespace:: 'monitoring',
+                        namespace:: $._config.namespace,
                         version:: $._config.versions.kubeStateMetrics,
                         image:: $._config.imageRepos.kubeStateMetrics + ':v' + $._config.versions.kubeStateMetrics,
                         service+: {


### PR DESCRIPTION
Use `$._config.namespace` instead of hard-coding `'monitoring'`.

Fixes #460 