### PR TITLE
ci: update release-0.3 e2e tests according to compat matrix

### DIFF
--- a/tests/e2e/main_test.go
+++ b/tests/e2e/main_test.go
@@ -87,7 +87,7 @@ func TestQueryPrometheus(t *testing.T) {
 	}
 
 	// Wait for pod to respond at queries at all. Then start verifying their results.
-	err := wait.Poll(5*time.Second, 1*time.Minute, func() (bool, error) {
+	err := wait.Poll(5*time.Second, 2*time.Minute, func() (bool, error) {
 		_, err := promClient.query("up")
 		return err == nil, nil
 	})


### PR DESCRIPTION
According to this PR #467, release-0.3 should be compatible with Kubernetes 1.14, 1.15, 1.16 and 1.17.

This comment suggested https://github.com/coreos/kube-prometheus/pull/467#issuecomment-604976807 updating e2e tests in order to validate this compatibility.

cc @lilic 