### PR TITLE
ci: update release-0.4 e2e tests according to compat matrix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ CONTAINER_CMD:=docker run --rm \
 		-v "$(shell go env GOCACHE):/.cache/go-build" \
 		-v "$(PWD):/go/src/github.com/coreos/kube-prometheus:Z" \
 		-w "/go/src/github.com/coreos/kube-prometheus" \
-		quay.io/coreos/jsonnet-ci
+		quay.io/coreos/jsonnet-ci:release-0.36
 
 all: generate fmt test
 

--- a/tests/e2e/main_test.go
+++ b/tests/e2e/main_test.go
@@ -87,7 +87,7 @@ func TestQueryPrometheus(t *testing.T) {
 	}
 
 	// Wait for pod to respond at queries at all. Then start verifying their results.
-	err := wait.Poll(5*time.Second, 1*time.Minute, func() (bool, error) {
+	err := wait.Poll(5*time.Second, 2*time.Minute, func() (bool, error) {
 		_, err := promClient.query("up")
 		return err == nil, nil
 	})

--- a/tests/e2e/travis-e2e.sh
+++ b/tests/e2e/travis-e2e.sh
@@ -13,16 +13,30 @@ chmod +x kubectl
 curl -Lo kind https://github.com/kubernetes-sigs/kind/releases/download/v0.6.1/kind-linux-amd64
 chmod +x kind
 
-./kind create cluster --image=kindest/node:v1.17.0
-export KUBECONFIG="$(./kind get kubeconfig-path)"
+run_e2e_tests() {
+    cluster_version=$1
 
-# create namespace, permissions, and CRDs
-./kubectl create -f manifests/setup
+    ./kind create cluster --image=kindest/node:$cluster_version
+    export KUBECONFIG="$(./kind get kubeconfig-path)"
 
-# wait for CRD creation to complete
-until ./kubectl get servicemonitors --all-namespaces ; do date; sleep 1; echo ""; done
+    # create namespace, permissions, and CRDs
+    ./kubectl create -f manifests/setup
 
-# create monitoring components
-./kubectl create -f manifests/
+    # wait for CRD creation to complete
+    until ./kubectl get servicemonitors --all-namespaces ; do date; sleep 1; echo ""; done
 
-make test-e2e
+    # create monitoring components
+    ./kubectl create -f manifests/
+
+    make test-e2e
+
+    ./kind delete cluster
+}
+
+cluster_compatible_versions=("v1.16.1" "v1.17.0")
+
+for cluster_version in "${cluster_compatible_versions[@]}"
+do
+    run_e2e_tests $cluster_version
+done
+


### PR DESCRIPTION
According to this PR #467, release-0.4 should be compatible with Kubernetes 1.16 and 1.17.

This comment suggested https://github.com/coreos/kube-prometheus/pull/467#issuecomment-604976807 updating e2e tests in order to validate this compatibility.

cc @lilic 