### PR TITLE
Remove version label from node-exporter selectors

### DIFF
--- a/jsonnet/kube-prometheus/node-exporter/node-exporter.libsonnet
+++ b/jsonnet/kube-prometheus/node-exporter/node-exporter.libsonnet
@@ -69,6 +69,11 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
       local containerEnv = container.envType;
 
       local podLabels = $._config.nodeExporter.labels;
+      local selectorLabels = {
+        [labelName]: $._config.nodeExporter.labels[labelName]
+        for labelName in std.objectFields($._config.nodeExporter.labels)
+        if !std.setMember(labelName, ['app.kubernetes.io/version'])
+      };
 
       local existsToleration = toleration.new() +
                                toleration.withOperator('Exists');
@@ -133,7 +138,7 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
       daemonset.mixin.metadata.withName('node-exporter') +
       daemonset.mixin.metadata.withNamespace($._config.namespace) +
       daemonset.mixin.metadata.withLabels(podLabels) +
-      daemonset.mixin.spec.selector.withMatchLabels(podLabels) +
+      daemonset.mixin.spec.selector.withMatchLabels(selectorLabels) +
       daemonset.mixin.spec.template.metadata.withLabels(podLabels) +
       daemonset.mixin.spec.template.spec.withTolerations([existsToleration]) +
       daemonset.mixin.spec.template.spec.withNodeSelector({ 'kubernetes.io/os': 'linux' }) +

--- a/manifests/node-exporter-daemonset.yaml
+++ b/manifests/node-exporter-daemonset.yaml
@@ -10,7 +10,6 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: node-exporter
-      app.kubernetes.io/version: v0.18.1
   template:
     metadata:
       labels:

--- a/manifests/node-exporter-service.yaml
+++ b/manifests/node-exporter-service.yaml
@@ -14,4 +14,3 @@ spec:
     targetPort: https
   selector:
     app.kubernetes.io/name: node-exporter
-    app.kubernetes.io/version: v0.18.1

--- a/manifests/node-exporter-serviceMonitor.yaml
+++ b/manifests/node-exporter-serviceMonitor.yaml
@@ -25,4 +25,3 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: node-exporter
-      app.kubernetes.io/version: v0.18.1


### PR DESCRIPTION
The `spec.selector` field is immutable on DaemonSets, so #463 ended up breaking the upgrade process (i.e. `kubectl apply -f manifests/`). This PR removes the version label from the selector, which fixes the issues with applying changes.