### PR TITLE
Adapter config duration fix.

### DIFF
--- a/jsonnet/kube-prometheus/prometheus-adapter/prometheus-adapter.libsonnet
+++ b/jsonnet/kube-prometheus/prometheus-adapter/prometheus-adapter.libsonnet
@@ -54,7 +54,7 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
             },
             containerLabel: 'container'
           },
-          window: 5,
+          window: '5m',
         },
       }
     },

--- a/manifests/prometheus-adapter-configMap.yaml
+++ b/manifests/prometheus-adapter-configMap.yaml
@@ -26,7 +26,7 @@ data:
               "resource": "namespace"
             "pod":
               "resource": "pod"
-      "window": 5
+      "window": 5m
 kind: ConfigMap
 metadata:
   name: adapter-config


### PR DESCRIPTION
Added specifier (as it was before change in 115721b) 'm' to the `window` key in prometheus-adapter-configmap.

Fixes #486