### PR TITLE
custom metrics v1beta2 api with k8s-prometheus-adapter v0.7.0

### DIFF
--- a/jsonnet/kube-prometheus/kube-prometheus-custom-metrics.libsonnet
+++ b/jsonnet/kube-prometheus/kube-prometheus-custom-metrics.libsonnet
@@ -134,6 +134,24 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
         versionPriority: 100,
       },
     },
+    customMetricsApiServiceV1Beta2: {
+      apiVersion: 'apiregistration.k8s.io/v1',
+      kind: 'APIService',
+      metadata: {
+        name: 'v1beta2.custom.metrics.k8s.io',
+      },
+      spec: {
+        service: {
+          name: $.prometheusAdapter.service.metadata.name,
+          namespace: $._config.namespace,
+        },
+        group: 'custom.metrics.k8s.io',
+        version: 'v1beta2',
+        insecureSkipTLSVerify: true,
+        groupPriorityMinimum: 100,
+        versionPriority: 200,
+      },
+    },
     customMetricsClusterRoleServerResources:
       local clusterRole = k.rbac.v1.clusterRole;
       local policyRule = clusterRole.rulesType;

--- a/jsonnet/kube-prometheus/prometheus-adapter/prometheus-adapter.libsonnet
+++ b/jsonnet/kube-prometheus/prometheus-adapter/prometheus-adapter.libsonnet
@@ -5,7 +5,7 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
     namespace: 'default',
 
     versions+:: {
-      prometheusAdapter: 'v0.5.0',
+      prometheusAdapter: 'v0.7.0',
     },
 
     imageRepos+:: {

--- a/manifests/prometheus-adapter-deployment.yaml
+++ b/manifests/prometheus-adapter-deployment.yaml
@@ -25,7 +25,7 @@ spec:
         - --metrics-relist-interval=1m
         - --prometheus-url=http://prometheus-k8s.monitoring.svc:9090/
         - --secure-port=6443
-        image: quay.io/coreos/k8s-prometheus-adapter-amd64:v0.5.0
+        image: quay.io/coreos/k8s-prometheus-adapter-amd64:v0.7.0
         name: prometheus-adapter
         ports:
         - containerPort: 6443


### PR DESCRIPTION
~Based on https://github.com/coreos/kube-prometheus/pull/374 (will rebase once merged)~ Rebased.

The change in `k8s-prometheus-adapter` https://github.com/DirectXMan12/k8s-prometheus-adapter/pull/247 also included a bump of `custom-metrics-apiserver`, which included https://github.com/kubernetes-sigs/custom-metrics-apiserver/pull/53.

This means the new custom metrics v1beta2 api is exposed by the adapter. v1beta2 adds the `targetAverageValue` property, which can automatically divide a metric by the number of running pods kubernetes/community#2055

~**Please don't merge yet, I still need to test this in our clusters**, but opening this for early feedback from folks more familiar with the adapter internals like @s-urbaniak.~