### PR TITLE
Revert "Remove field preserveUnknownFields from CRDs"

### DIFF
--- a/jsonnet/kube-prometheus/kube-prometheus.libsonnet
+++ b/jsonnet/kube-prometheus/kube-prometheus.libsonnet
@@ -18,38 +18,7 @@ local configMapList = k3.core.v1.configMapList;
   kubePrometheus+:: {
     namespace: k.core.v1.namespace.new($._config.namespace),
   },
-  prometheusOperator+::
-  {
-    '0alertmanagerCustomResourceDefinition'+: {
-      spec: std.mergePatch(super.spec, {
-        preserveUnknownFields: null,
-      }),
-    },
-    '0prometheusCustomResourceDefinition'+: {
-      spec: std.mergePatch(super.spec, {
-        preserveUnknownFields: null,
-      }),
-    },
-    '0servicemonitorCustomResourceDefinition'+: {
-      spec: std.mergePatch(super.spec, {
-        preserveUnknownFields: null,
-      }),
-    },
-    '0podmonitorCustomResourceDefinition'+: {
-      spec: std.mergePatch(super.spec, {
-        preserveUnknownFields: null,
-      }),
-    },
-    '0prometheusruleCustomResourceDefinition'+: {
-      spec: std.mergePatch(super.spec, {
-        preserveUnknownFields: null,
-      }),
-    },
-    '0thanosrulerCustomResourceDefinition'+: {
-      spec: std.mergePatch(super.spec, {
-        preserveUnknownFields: null,
-      }),
-    },
+  prometheusOperator+:: {
     service+: {
       spec+: {
         ports: [

--- a/manifests/setup/prometheus-operator-0alertmanagerCustomResourceDefinition.yaml
+++ b/manifests/setup/prometheus-operator-0alertmanagerCustomResourceDefinition.yaml
@@ -24,6 +24,7 @@ spec:
     listKind: AlertmanagerList
     plural: alertmanagers
     singular: alertmanager
+  preserveUnknownFields: false
   scope: Namespaced
   subresources: {}
   validation:

--- a/manifests/setup/prometheus-operator-0podmonitorCustomResourceDefinition.yaml
+++ b/manifests/setup/prometheus-operator-0podmonitorCustomResourceDefinition.yaml
@@ -12,6 +12,7 @@ spec:
     listKind: PodMonitorList
     plural: podmonitors
     singular: podmonitor
+  preserveUnknownFields: false
   scope: Namespaced
   validation:
     openAPIV3Schema:

--- a/manifests/setup/prometheus-operator-0prometheusCustomResourceDefinition.yaml
+++ b/manifests/setup/prometheus-operator-0prometheusCustomResourceDefinition.yaml
@@ -24,6 +24,7 @@ spec:
     listKind: PrometheusList
     plural: prometheuses
     singular: prometheus
+  preserveUnknownFields: false
   scope: Namespaced
   subresources: {}
   validation:

--- a/manifests/setup/prometheus-operator-0prometheusruleCustomResourceDefinition.yaml
+++ b/manifests/setup/prometheus-operator-0prometheusruleCustomResourceDefinition.yaml
@@ -12,6 +12,7 @@ spec:
     listKind: PrometheusRuleList
     plural: prometheusrules
     singular: prometheusrule
+  preserveUnknownFields: false
   scope: Namespaced
   validation:
     openAPIV3Schema:

--- a/manifests/setup/prometheus-operator-0servicemonitorCustomResourceDefinition.yaml
+++ b/manifests/setup/prometheus-operator-0servicemonitorCustomResourceDefinition.yaml
@@ -12,6 +12,7 @@ spec:
     listKind: ServiceMonitorList
     plural: servicemonitors
     singular: servicemonitor
+  preserveUnknownFields: false
   scope: Namespaced
   validation:
     openAPIV3Schema:

--- a/manifests/setup/prometheus-operator-0thanosrulerCustomResourceDefinition.yaml
+++ b/manifests/setup/prometheus-operator-0thanosrulerCustomResourceDefinition.yaml
@@ -12,6 +12,7 @@ spec:
     listKind: ThanosRulerList
     plural: thanosrulers
     singular: thanosruler
+  preserveUnknownFields: false
   scope: Namespaced
   validation:
     openAPIV3Schema:


### PR DESCRIPTION
The preserveUnknownFields flag was removed previously to maintain support for kube v1.14.  With the move to CRD v1 (from v1beta1) we will no longer be able to support kube 1.14 and earlier, so I think it makes sense now to revert the previous change.

See https://github.com/coreos/prometheus-operator/issues/3178