### PR TITLE
update generated files for prometheus operator v0.39.0

### DIFF
--- a/manifests/setup/prometheus-operator-0alertmanagerCustomResourceDefinition.yaml
+++ b/manifests/setup/prometheus-operator-0alertmanagerCustomResourceDefinition.yaml
@@ -12,7 +12,6 @@ spec:
     listKind: AlertmanagerList
     plural: alertmanagers
     singular: alertmanager
-  preserveUnknownFields: false
   scope: Namespaced
   versions:
   - additionalPrinterColumns:

--- a/manifests/setup/prometheus-operator-0podmonitorCustomResourceDefinition.yaml
+++ b/manifests/setup/prometheus-operator-0podmonitorCustomResourceDefinition.yaml
@@ -12,7 +12,6 @@ spec:
     listKind: PodMonitorList
     plural: podmonitors
     singular: podmonitor
-  preserveUnknownFields: false
   scope: Namespaced
   versions:
   - name: v1

--- a/manifests/setup/prometheus-operator-0prometheusCustomResourceDefinition.yaml
+++ b/manifests/setup/prometheus-operator-0prometheusCustomResourceDefinition.yaml
@@ -12,7 +12,6 @@ spec:
     listKind: PrometheusList
     plural: prometheuses
     singular: prometheus
-  preserveUnknownFields: false
   scope: Namespaced
   versions:
   - additionalPrinterColumns:

--- a/manifests/setup/prometheus-operator-0prometheusruleCustomResourceDefinition.yaml
+++ b/manifests/setup/prometheus-operator-0prometheusruleCustomResourceDefinition.yaml
@@ -12,7 +12,6 @@ spec:
     listKind: PrometheusRuleList
     plural: prometheusrules
     singular: prometheusrule
-  preserveUnknownFields: false
   scope: Namespaced
   versions:
   - name: v1

--- a/manifests/setup/prometheus-operator-0servicemonitorCustomResourceDefinition.yaml
+++ b/manifests/setup/prometheus-operator-0servicemonitorCustomResourceDefinition.yaml
@@ -12,7 +12,6 @@ spec:
     listKind: ServiceMonitorList
     plural: servicemonitors
     singular: servicemonitor
-  preserveUnknownFields: false
   scope: Namespaced
   versions:
   - name: v1

--- a/manifests/setup/prometheus-operator-0thanosrulerCustomResourceDefinition.yaml
+++ b/manifests/setup/prometheus-operator-0thanosrulerCustomResourceDefinition.yaml
@@ -12,7 +12,6 @@ spec:
     listKind: ThanosRulerList
     plural: thanosrulers
     singular: thanosruler
-  preserveUnknownFields: false
   scope: Namespaced
   versions:
   - name: v1


### PR DESCRIPTION
Updating to prometheus-operator v0.39 and then merging #519 caused the generated files to become out of sync.  This is change is just the result of a "make generate" against current HEAD