### PR TITLE
Add new variable {node selector}

### DIFF
--- a/jsonnet/kube-prometheus/alertmanager/alertmanager.libsonnet
+++ b/jsonnet/kube-prometheus/alertmanager/alertmanager.libsonnet
@@ -14,6 +14,7 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
 
     alertmanager+:: {
       name: 'main',
+      nodeSelector: { 'kubernetes.io/os': 'linux' },
       config: {
         global: {
           resolve_timeout: '5m',
@@ -142,7 +143,7 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
           replicas: $._config.alertmanager.replicas,
           version: $._config.versions.alertmanager,
           image: $._config.imageRepos.alertmanager + ':' + $._config.versions.alertmanager,
-          nodeSelector: { 'kubernetes.io/os': 'linux' },
+          nodeSelector: $._config.alertmanager.nodeSelector,
           serviceAccountName: 'alertmanager-' + $._config.alertmanager.name,
           securityContext: {
             runAsUser: 1000,

--- a/jsonnet/kube-prometheus/kube-state-metrics/kube-state-metrics.libsonnet
+++ b/jsonnet/kube-prometheus/kube-state-metrics/kube-state-metrics.libsonnet
@@ -9,6 +9,7 @@
     kubeStateMetrics+:: {
       scrapeInterval: '30s',
       scrapeTimeout: '30s',
+      nodeSelector: { 'kubernetes.io/os': 'linux' },
     },
   },
   kubeStateMetrics+:: (import 'kube-state-metrics/kube-state-metrics.libsonnet') +
@@ -18,6 +19,7 @@
                         namespace:: $._config.namespace,
                         version:: $._config.versions.kubeStateMetrics,
                         image:: $._config.imageRepos.kubeStateMetrics + ':v' + $._config.versions.kubeStateMetrics,
+                        nodeSelector:: $._config.kubeStateMetrics.nodeSelector,
                         service+: {
                           spec+: {
                             ports: [
@@ -44,6 +46,7 @@
                                   readinessProbe:: null,
                                   args: ['--host=127.0.0.1', '--port=8081', '--telemetry-host=127.0.0.1', '--telemetry-port=8082'],
                                 }, super.containers),
+                                nodeSelector: ksm.nodeSelector
                               },
                             },
                           },

--- a/jsonnet/kube-prometheus/prometheus-adapter/prometheus-adapter.libsonnet
+++ b/jsonnet/kube-prometheus/prometheus-adapter/prometheus-adapter.libsonnet
@@ -14,6 +14,7 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
 
     prometheusAdapter+:: {
       name: 'prometheus-adapter',
+      nodeSelector: { 'kubernetes.io/os': 'linux' },
       labels: { name: $._config.prometheusAdapter.name },
       prometheusURL: 'http://prometheus-' + $._config.prometheus.name + '.' + $._config.namespace + '.svc:9090/',
       config: {
@@ -126,7 +127,7 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
       deployment.mixin.metadata.withNamespace($._config.namespace) +
       deployment.mixin.spec.selector.withMatchLabels($._config.prometheusAdapter.labels) +
       deployment.mixin.spec.template.spec.withServiceAccountName($.prometheusAdapter.serviceAccount.metadata.name) +
-      deployment.mixin.spec.template.spec.withNodeSelector({ 'kubernetes.io/os': 'linux' }) +
+      deployment.mixin.spec.template.spec.withNodeSelector($._config.prometheusAdapter.nodeSelector) +
       deployment.mixin.spec.strategy.rollingUpdate.withMaxSurge(1) +
       deployment.mixin.spec.strategy.rollingUpdate.withMaxUnavailable(0) +
       deployment.mixin.spec.template.spec.withVolumes([

--- a/jsonnet/kube-prometheus/prometheus/prometheus.libsonnet
+++ b/jsonnet/kube-prometheus/prometheus/prometheus.libsonnet
@@ -21,6 +21,7 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
       name: 'k8s',
       replicas: 2,
       rules: {},
+      nodeSelector: { 'kubernetes.io/os': 'linux' },
       namespaces: ['default', 'kube-system', $._config.namespace],
     },
   },
@@ -184,7 +185,7 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
           podMonitorSelector: {},
           serviceMonitorNamespaceSelector: {},
           podMonitorNamespaceSelector: {},
-          nodeSelector: { 'kubernetes.io/os': 'linux' },
+          nodeSelector: $._config.prometheus.nodeSelector,
           ruleSelector: selector.withMatchLabels({
             role: 'alert-rules',
             prometheus: p.name,


### PR DESCRIPTION
**Feature**
Add new variable node selector to applications for controlling nodes for deploying. 

**For what**
For example, you have several zones like DMZ & internal. You don't want to deploy a monitoring system in the DMZ zone, so you need to change the default node selector.

**TODO**

- [ ] Prometheus
- [ ] Prometheus Adapter
- [ ] Alertmanager
- [ ] kube metrics server

Note: Grafana in another repository. For her will be another PR.

**UPD#1**: Broke deployment in OKD. Will be re-write.