### PR TITLE
Update release-0.5 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ The following versions are supported and work as we test against these versions 
 |-----------------------|-----------------|-----------------|-----------------|-----------------|-----------------|
 | `release-0.3`         | ✔              | ✔              | ✔              | ✔              | ✗
 | `release-0.4`         | ✗              | ✗              | ✔ (v1.16.5+)   | ✔              | ✗
-| `release-0.5`         | ✗              | ✗              | ✗              | ✔              | ✔
+| `release-0.5`         | ✗              | ✗              | ✗              | ✗              | ✔
 | `HEAD`                | ✗              | ✗              | ✗              | ✗              | ✔
 
 Note: Due to [two](https://github.com/kubernetes/kubernetes/issues/83778) [bugs](https://github.com/kubernetes/kubernetes/issues/86359) in Kubernetes v1.16.1, and prior to Kubernetes v1.16.5 the kube-prometheus release-0.4 branch only supports v1.16.5 and higher.  The `extension-apiserver-authentication-reader` role in the kube-system namespace can be manually edited to include list and watch permissions in order to workaround the second issue with Kubernetes v1.16.2 through v1.16.4.


### PR DESCRIPTION
The following kubernetes-mixin PR https://github.com/kubernetes-monitoring/kubernetes-mixin/pull/408 is breaking Kubernetes 1.17 compatibility.
