### PR TITLE
Remove kubernetes 1.17 compatibility in release-0.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ The following versions are supported and work as we test against these versions 
 |-----------------------|-----------------|-----------------|-----------------|-----------------|-----------------|
 | `release-0.3`         | ✔              | ✔              | ✔              | ✔              | ✗
 | `release-0.4`         | ✗              | ✗              | ✔              | ✔              | ✗
-| `release-0.5`         | ✗              | ✗              | ✗              | ✔              | ✔
+| `release-0.5`         | ✗              | ✗              | ✗              | ✗              | ✔
 | `HEAD`                | ✗              | ✗              | ✗              | ✗              | ✔
 
 ## Quickstart

--- a/tests/e2e/travis-e2e.sh
+++ b/tests/e2e/travis-e2e.sh
@@ -31,7 +31,7 @@ run_e2e_tests() {
     make test-e2e
     ./kind delete cluster
 }
-cluster_compatible_versions=("v1.17.0" "v1.18.0")
+cluster_compatible_versions=("v1.18.0")
 
 for cluster_version in "${cluster_compatible_versions[@]}"
 do


### PR DESCRIPTION
kubernetes-mixin release-0.4 is only supported by Kubernetes 1.18+