### PR TITLE
Update endpoints

### DIFF
--- a/docs/developing-prometheus-rules-and-grafana-dashboards.md
+++ b/docs/developing-prometheus-rules-and-grafana-dashboards.md
@@ -252,30 +252,32 @@ local kp = (import 'kube-prometheus/kube-prometheus.libsonnet') + {
   _config+:: {
     namespace: 'monitoring',
   },
-  grafanaDashboards+:: {
-    'my-dashboard.json':
-      dashboard.new('My Dashboard')
-      .addTemplate(
-        {
-          current: {
-            text: 'Prometheus',
-            value: 'Prometheus',
+  grafana+:: {
+    dashboards+:: {
+      'my-dashboard.json':
+        dashboard.new('My Dashboard')
+        .addTemplate(
+          {
+            current: {
+              text: 'Prometheus',
+              value: 'Prometheus',
+            },
+            hide: 0,
+            label: null,
+            name: 'datasource',
+            options: [],
+            query: 'prometheus',
+            refresh: 1,
+            regex: '',
+            type: 'datasource',
           },
-          hide: 0,
-          label: null,
-          name: 'datasource',
-          options: [],
-          query: 'prometheus',
-          refresh: 1,
-          regex: '',
-          type: 'datasource',
-        },
-      )
-      .addRow(
-        row.new()
-        .addPanel(graphPanel.new('My Panel', span=6, datasource='$datasource')
-                  .addTarget(prometheus.target('vector(1)')))
-      ),
+        )
+        .addRow(
+          row.new()
+          .addPanel(graphPanel.new('My Panel', span=6, datasource='$datasource')
+                    .addTarget(prometheus.target('vector(1)')))
+        ),
+    },
   },
 };
 
@@ -298,8 +300,13 @@ local kp = (import 'kube-prometheus/kube-prometheus.libsonnet') + {
   _config+:: {
     namespace: 'monitoring',
   },
-  grafanaDashboards+:: {
+  grafanaDashboards+:: { //  monitoring-mixin compatibility
     'my-dashboard.json': (import 'example-grafana-dashboard.json'),
+  },
+  grafana+:: {
+    dashboards+:: { // use this method to import your dashboards to Grafana
+      'my-dashboard.json': (import 'example-grafana-dashboard.json'),
+    },
   },
 };
 
@@ -319,8 +326,10 @@ local kp = (import 'kube-prometheus/kube-prometheus.libsonnet') + {
   _config+:: {
     namespace: 'monitoring',
   },
-  rawGrafanaDashboards+:: {
-    'my-dashboard.json': (importstr 'example-grafana-dashboard.json'),
+  grafana+:: {
+    rawDashboards+:: {
+      'my-dashboard.json': (importstr 'example-grafana-dashboard.json'),
+    },
   },
 };
 

--- a/jsonnet/kube-prometheus/prometheus-adapter/prometheus-adapter.libsonnet
+++ b/jsonnet/kube-prometheus/prometheus-adapter/prometheus-adapter.libsonnet
@@ -15,7 +15,7 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
     prometheusAdapter+:: {
       name: 'prometheus-adapter',
       labels: { name: $._config.prometheusAdapter.name },
-      prometheusURL: 'http://prometheus-' + $._config.prometheus.name + '.' + $._config.namespace + '.svc:9090/',
+      prometheusURL: 'http://prometheus-' + $._config.prometheus.name + '.' + $._config.namespace + '.svc.cluster.local:9090/',
       config: {
         resourceRules: {
           cpu: {

--- a/jsonnetfile.lock.json
+++ b/jsonnetfile.lock.json
@@ -4,7 +4,7 @@
     {
       "source": {
         "git": {
-          "remote": "https://github.com/brancz/kubernetes-grafana",
+          "remote": "https://github.com/brancz/kubernetes-grafana.git",
           "subdir": "grafana"
         }
       },
@@ -14,17 +14,17 @@
     {
       "source": {
         "git": {
-          "remote": "https://github.com/coreos/etcd",
+          "remote": "https://github.com/coreos/etcd.git",
           "subdir": "Documentation/etcd-mixin"
         }
       },
-      "version": "1166b1f195efae31439c7b3c913b4ef02e7df889",
-      "sum": "Ko3qhNfC2vN/houLh6C0Ryacjv70gl0DVPGU/PQ4OD0="
+      "version": "d8c8f903eee10b8391abaef7758c38b2cd393c55",
+      "sum": "pk7mLpdUrHuJKkj2vhD6LGMU7P+oYYooBXAeZyZa398="
     },
     {
       "source": {
         "git": {
-          "remote": "https://github.com/coreos/prometheus-operator",
+          "remote": "https://github.com/coreos/prometheus-operator.git",
           "subdir": "jsonnet/prometheus-operator"
         }
       },
@@ -34,27 +34,27 @@
     {
       "source": {
         "git": {
-          "remote": "https://github.com/grafana/grafonnet-lib",
+          "remote": "https://github.com/grafana/grafonnet-lib.git",
           "subdir": "grafonnet"
         }
       },
-      "version": "906768d46973e022594d3f03d82c5a51d86de2cc",
-      "sum": "J3Vp0EVbxTObr6KydLXsi4Rc0ssNVAEuwLc0NQ+4wqU="
+      "version": "8fb95bd89990e493a8534205ee636bfcb8db67bd",
+      "sum": "tDuuSKE9f4Ew2bjBM33Rs6behLEAzkmKkShSt+jpAak="
     },
     {
       "source": {
         "git": {
-          "remote": "https://github.com/grafana/jsonnet-libs",
+          "remote": "https://github.com/grafana/jsonnet-libs.git",
           "subdir": "grafana-builder"
         }
       },
-      "version": "cb6bc2780a39afbbf9d4ee64fec8d1152023aee9",
+      "version": "881db2241f0c5007c3e831caf34b0c645202b4ab",
       "sum": "slxrtftVDiTlQK22ertdfrg4Epnq97gdrLI63ftUfaE="
     },
     {
       "source": {
         "git": {
-          "remote": "https://github.com/ksonnet/ksonnet-lib",
+          "remote": "https://github.com/ksonnet/ksonnet-lib.git",
           "subdir": ""
         }
       },
@@ -65,61 +65,61 @@
     {
       "source": {
         "git": {
-          "remote": "https://github.com/kubernetes-monitoring/kubernetes-mixin",
+          "remote": "https://github.com/kubernetes-monitoring/kubernetes-mixin.git",
           "subdir": ""
         }
       },
-      "version": "3cc34f995c31ed6e1e92024fed1912d63569c39f",
-      "sum": "r5Fg4KgiBtsFPCCHtM3Cb4CEgnizLyK97srDNAcjr+Y="
+      "version": "e9916660bd4a15fc72bb6debbaf5c41dec22d2ae",
+      "sum": "CNYqV6GdCnydHpa/afkXK5TgNL0VMLHCOR5THS7RmnM="
     },
     {
       "source": {
         "git": {
-          "remote": "https://github.com/kubernetes-monitoring/kubernetes-mixin",
+          "remote": "https://github.com/kubernetes-monitoring/kubernetes-mixin.git",
           "subdir": "lib/promgrafonnet"
         }
       },
-      "version": "3cc34f995c31ed6e1e92024fed1912d63569c39f",
+      "version": "e9916660bd4a15fc72bb6debbaf5c41dec22d2ae",
       "sum": "VhgBM39yv0f4bKv8VfGg4FXkg573evGDRalip9ypKbc="
     },
     {
       "source": {
         "git": {
-          "remote": "https://github.com/kubernetes/kube-state-metrics",
+          "remote": "https://github.com/kubernetes/kube-state-metrics.git",
           "subdir": "jsonnet/kube-state-metrics"
         }
       },
-      "version": "52fe3a268bd78c8f32a03361e28fdf23c41512c5",
+      "version": "c766f5cb3e9e947a5234460f526c763e1e567113",
       "sum": "cJjGZaLBjcIGrLHZLjRPU9c3KL+ep9rZTb9dbALSKqA="
     },
     {
       "source": {
         "git": {
-          "remote": "https://github.com/kubernetes/kube-state-metrics",
+          "remote": "https://github.com/kubernetes/kube-state-metrics.git",
           "subdir": "jsonnet/kube-state-metrics-mixin"
         }
       },
-      "version": "52fe3a268bd78c8f32a03361e28fdf23c41512c5",
-      "sum": "E1GGavnf9PCWBm4WVrxWnc0FIj72UcbcweqGioWrOdU="
+      "version": "c766f5cb3e9e947a5234460f526c763e1e567113",
+      "sum": "o5avaguRsfFwYFNen00ZEsub1x4i8Z/ZZ2QoEjFMff8="
     },
     {
       "source": {
         "git": {
-          "remote": "https://github.com/prometheus/node_exporter",
+          "remote": "https://github.com/prometheus/node_exporter.git",
           "subdir": "docs/node-mixin"
         }
       },
-      "version": "d4d2e1db98152ab6c94dc9a12a997950e0be2416",
-      "sum": "ZwrC0+4o1xD6+oPBu1p+rBXLlf6pMBD9rT8ygyl2aW0="
+      "version": "3799895d414ef94822df11a80fe60565fc8bbd07",
+      "sum": "3jFV2qsc/GZe2GADswTYqxxP2zGOiANTj73W/VNFGqc="
     },
     {
       "source": {
         "git": {
-          "remote": "https://github.com/prometheus/prometheus",
+          "remote": "https://github.com/prometheus/prometheus.git",
           "subdir": "documentation/prometheus-mixin"
         }
       },
-      "version": "209d4bb8a1491f4535cc6d991681e7dc03bb1d56",
+      "version": "3c753aba5f3ac334e87c1203ddc6c27cd0005bf3",
       "sum": "kRb3XBTe/AALDcaTFfyuiKqzhxtLvihBkVkvJ5cUd/I=",
       "name": "prometheus"
     },

--- a/manifests/grafana-dashboardDefinitions.yaml
+++ b/manifests/grafana-dashboardDefinitions.yaml
@@ -40,6 +40,7 @@ items:
                           ],
                           "datasource": "$datasource",
                           "decimals": 3,
+                          "description": "How many percent of requests (both read and write) in 30 days have been answered successfully and fast enough?",
                           "format": "percentunit",
                           "gauge": {
                               "maxValue": 100,
@@ -99,7 +100,7 @@ items:
                               }
                           ],
                           "thresholds": "",
-                          "title": "Availability (30d) > 99.000",
+                          "title": "Availability (30d) > 99.000%",
                           "tooltip": {
                               "shared": false
                           },
@@ -123,7 +124,8 @@ items:
                           "dashes": false,
                           "datasource": "$datasource",
                           "decimals": 3,
-                          "fill": 1,
+                          "description": "How much error budget is left looking at our 0.990% availability gurantees?",
+                          "fill": 10,
                           "gridPos": {
 
                           },
@@ -136,6 +138,7 @@ items:
                               "min": false,
                               "rightSide": false,
                               "show": true,
+                              "sideWidth": null,
                               "total": false,
                               "values": false
                           },
@@ -171,7 +174,7 @@ items:
                           ],
                           "timeFrom": null,
                           "timeShift": null,
-                          "title": "ErrorBudget (30d) > 99.000",
+                          "title": "ErrorBudget (30d) > 99.000%",
                           "tooltip": {
                               "shared": false,
                               "sort": 0,
@@ -232,6 +235,7 @@ items:
                           ],
                           "datasource": "$datasource",
                           "decimals": 3,
+                          "description": "How many percent of read requests (LIST,GET) in 30 days have been answered successfully and fast enough?",
                           "format": "percentunit",
                           "gauge": {
                               "maxValue": 100,
@@ -314,7 +318,8 @@ items:
                           "dashLength": 10,
                           "dashes": false,
                           "datasource": "$datasource",
-                          "fill": 1,
+                          "description": "How many read requests (LIST,GET) per second do the apiservers get by code?",
+                          "fill": 10,
                           "gridPos": {
 
                           },
@@ -327,6 +332,7 @@ items:
                               "min": false,
                               "rightSide": false,
                               "show": true,
+                              "sideWidth": null,
                               "total": false,
                               "values": false
                           },
@@ -342,18 +348,33 @@ items:
                           "renderer": "flot",
                           "repeat": null,
                           "seriesOverrides": [
-
+                              {
+                                  "alias": "/2../i",
+                                  "color": "#56A64B"
+                              },
+                              {
+                                  "alias": "/3../i",
+                                  "color": "#F2CC0C"
+                              },
+                              {
+                                  "alias": "/4../i",
+                                  "color": "#3274D9"
+                              },
+                              {
+                                  "alias": "/5../i",
+                                  "color": "#E02F44"
+                              }
                           ],
                           "spaceLength": 10,
                           "span": 3,
-                          "stack": false,
+                          "stack": true,
                           "steppedLine": false,
                           "targets": [
                               {
-                                  "expr": "sum(code_resource:apiserver_request_total:rate5m{verb=\"read\"})",
+                                  "expr": "sum by (code) (code_resource:apiserver_request_total:rate5m{verb=\"read\"})",
                                   "format": "time_series",
                                   "intervalFactor": 2,
-                                  "legendFormat": "",
+                                  "legendFormat": "{{ code }}",
                                   "refId": "A"
                               }
                           ],
@@ -405,6 +426,7 @@ items:
                           "dashLength": 10,
                           "dashes": false,
                           "datasource": "$datasource",
+                          "description": "How many percent of read requests (LIST,GET) per second are returned with errors (5xx)?",
                           "fill": 1,
                           "gridPos": {
 
@@ -418,6 +440,7 @@ items:
                               "min": false,
                               "rightSide": false,
                               "show": true,
+                              "sideWidth": null,
                               "total": false,
                               "values": false
                           },
@@ -475,7 +498,7 @@ items:
                                   "label": null,
                                   "logBase": 1,
                                   "max": null,
-                                  "min": null,
+                                  "min": 0,
                                   "show": true
                               },
                               {
@@ -483,7 +506,7 @@ items:
                                   "label": null,
                                   "logBase": 1,
                                   "max": null,
-                                  "min": null,
+                                  "min": 0,
                                   "show": true
                               }
                           ]
@@ -496,6 +519,7 @@ items:
                           "dashLength": 10,
                           "dashes": false,
                           "datasource": "$datasource",
+                          "description": "How many seconds is the 99th percentile for reading (LIST|GET) a given resource?",
                           "fill": 1,
                           "gridPos": {
 
@@ -509,6 +533,7 @@ items:
                               "min": false,
                               "rightSide": false,
                               "show": true,
+                              "sideWidth": null,
                               "total": false,
                               "values": false
                           },
@@ -603,6 +628,7 @@ items:
                           ],
                           "datasource": "$datasource",
                           "decimals": 3,
+                          "description": "How many percent of write requests (POST|PUT|PATCH|DELETE) in 30 days have been answered successfully and fast enough?",
                           "format": "percentunit",
                           "gauge": {
                               "maxValue": 100,
@@ -685,7 +711,8 @@ items:
                           "dashLength": 10,
                           "dashes": false,
                           "datasource": "$datasource",
-                          "fill": 1,
+                          "description": "How many write requests (POST|PUT|PATCH|DELETE) per second do the apiservers get by code?",
+                          "fill": 10,
                           "gridPos": {
 
                           },
@@ -698,6 +725,7 @@ items:
                               "min": false,
                               "rightSide": false,
                               "show": true,
+                              "sideWidth": null,
                               "total": false,
                               "values": false
                           },
@@ -713,18 +741,33 @@ items:
                           "renderer": "flot",
                           "repeat": null,
                           "seriesOverrides": [
-
+                              {
+                                  "alias": "/2../i",
+                                  "color": "#56A64B"
+                              },
+                              {
+                                  "alias": "/3../i",
+                                  "color": "#F2CC0C"
+                              },
+                              {
+                                  "alias": "/4../i",
+                                  "color": "#3274D9"
+                              },
+                              {
+                                  "alias": "/5../i",
+                                  "color": "#E02F44"
+                              }
                           ],
                           "spaceLength": 10,
                           "span": 3,
-                          "stack": false,
+                          "stack": true,
                           "steppedLine": false,
                           "targets": [
                               {
-                                  "expr": "sum(code_resource:apiserver_request_total:rate5m{verb=\"write\"})",
+                                  "expr": "sum by (code) (code_resource:apiserver_request_total:rate5m{verb=\"write\"})",
                                   "format": "time_series",
                                   "intervalFactor": 2,
-                                  "legendFormat": "",
+                                  "legendFormat": "{{ code }}",
                                   "refId": "A"
                               }
                           ],
@@ -776,6 +819,7 @@ items:
                           "dashLength": 10,
                           "dashes": false,
                           "datasource": "$datasource",
+                          "description": "How many percent of write requests (POST|PUT|PATCH|DELETE) per second are returned with errors (5xx)?",
                           "fill": 1,
                           "gridPos": {
 
@@ -789,6 +833,7 @@ items:
                               "min": false,
                               "rightSide": false,
                               "show": true,
+                              "sideWidth": null,
                               "total": false,
                               "values": false
                           },
@@ -846,7 +891,7 @@ items:
                                   "label": null,
                                   "logBase": 1,
                                   "max": null,
-                                  "min": null,
+                                  "min": 0,
                                   "show": true
                               },
                               {
@@ -854,7 +899,7 @@ items:
                                   "label": null,
                                   "logBase": 1,
                                   "max": null,
-                                  "min": null,
+                                  "min": 0,
                                   "show": true
                               }
                           ]
@@ -867,6 +912,7 @@ items:
                           "dashLength": 10,
                           "dashes": false,
                           "datasource": "$datasource",
+                          "description": "How many seconds is the 99th percentile for writing (POST|PUT|PATCH|DELETE) a given resource?",
                           "fill": 1,
                           "gridPos": {
 
@@ -880,6 +926,7 @@ items:
                               "min": false,
                               "rightSide": false,
                               "show": true,
+                              "sideWidth": null,
                               "total": false,
                               "values": false
                           },
@@ -964,318 +1011,18 @@ items:
                   "collapsed": false,
                   "panels": [
                       {
-                          "cacheTimeout": null,
-                          "colorBackground": false,
-                          "colorValue": false,
-                          "colors": [
-                              "#299c46",
-                              "rgba(237, 129, 40, 0.89)",
-                              "#d44a3a"
-                          ],
-                          "datasource": "$datasource",
-                          "format": "none",
-                          "gauge": {
-                              "maxValue": 100,
-                              "minValue": 0,
-                              "show": false,
-                              "thresholdLabels": false,
-                              "thresholdMarkers": true
+                          "aliasColors": {
+
                           },
+                          "bars": false,
+                          "dashLength": 10,
+                          "dashes": false,
+                          "datasource": "$datasource",
+                          "fill": 1,
                           "gridPos": {
 
                           },
                           "id": 12,
-                          "interval": null,
-                          "links": [
-
-                          ],
-                          "mappingType": 1,
-                          "mappingTypes": [
-                              {
-                                  "name": "value to text",
-                                  "value": 1
-                              },
-                              {
-                                  "name": "range to text",
-                                  "value": 2
-                              }
-                          ],
-                          "maxDataPoints": 100,
-                          "nullPointMode": "connected",
-                          "nullText": null,
-                          "postfix": "",
-                          "postfixFontSize": "50%",
-                          "prefix": "",
-                          "prefixFontSize": "50%",
-                          "rangeMaps": [
-                              {
-                                  "from": "null",
-                                  "text": "N/A",
-                                  "to": "null"
-                              }
-                          ],
-                          "span": 2,
-                          "sparkline": {
-                              "fillColor": "rgba(31, 118, 189, 0.18)",
-                              "full": false,
-                              "lineColor": "rgb(31, 120, 193)",
-                              "show": false
-                          },
-                          "tableColumn": "",
-                          "targets": [
-                              {
-                                  "expr": "sum(up{job=\"apiserver\", cluster=\"$cluster\"})",
-                                  "format": "time_series",
-                                  "intervalFactor": 2,
-                                  "legendFormat": "",
-                                  "refId": "A"
-                              }
-                          ],
-                          "thresholds": "",
-                          "title": "Up",
-                          "tooltip": {
-                              "shared": false
-                          },
-                          "type": "singlestat",
-                          "valueFontSize": "80%",
-                          "valueMaps": [
-                              {
-                                  "op": "=",
-                                  "text": "N/A",
-                                  "value": "null"
-                              }
-                          ],
-                          "valueName": "min"
-                      },
-                      {
-                          "aliasColors": {
-
-                          },
-                          "bars": false,
-                          "dashLength": 10,
-                          "dashes": false,
-                          "datasource": "$datasource",
-                          "fill": 1,
-                          "gridPos": {
-
-                          },
-                          "id": 13,
-                          "legend": {
-                              "alignAsTable": false,
-                              "avg": false,
-                              "current": false,
-                              "max": false,
-                              "min": false,
-                              "rightSide": false,
-                              "show": true,
-                              "total": false,
-                              "values": false
-                          },
-                          "lines": true,
-                          "linewidth": 1,
-                          "links": [
-
-                          ],
-                          "nullPointMode": "null",
-                          "percentage": false,
-                          "pointradius": 5,
-                          "points": false,
-                          "renderer": "flot",
-                          "repeat": null,
-                          "seriesOverrides": [
-
-                          ],
-                          "spaceLength": 10,
-                          "span": 5,
-                          "stack": false,
-                          "steppedLine": false,
-                          "targets": [
-                              {
-                                  "expr": "sum(rate(apiserver_request_total{job=\"apiserver\", instance=~\"$instance\",code=~\"2..\", cluster=\"$cluster\"}[5m]))",
-                                  "format": "time_series",
-                                  "intervalFactor": 2,
-                                  "legendFormat": "2xx",
-                                  "refId": "A"
-                              },
-                              {
-                                  "expr": "sum(rate(apiserver_request_total{job=\"apiserver\", instance=~\"$instance\",code=~\"3..\", cluster=\"$cluster\"}[5m]))",
-                                  "format": "time_series",
-                                  "intervalFactor": 2,
-                                  "legendFormat": "3xx",
-                                  "refId": "B"
-                              },
-                              {
-                                  "expr": "sum(rate(apiserver_request_total{job=\"apiserver\", instance=~\"$instance\",code=~\"4..\", cluster=\"$cluster\"}[5m]))",
-                                  "format": "time_series",
-                                  "intervalFactor": 2,
-                                  "legendFormat": "4xx",
-                                  "refId": "C"
-                              },
-                              {
-                                  "expr": "sum(rate(apiserver_request_total{job=\"apiserver\", instance=~\"$instance\",code=~\"5..\", cluster=\"$cluster\"}[5m]))",
-                                  "format": "time_series",
-                                  "intervalFactor": 2,
-                                  "legendFormat": "5xx",
-                                  "refId": "D"
-                              }
-                          ],
-                          "thresholds": [
-
-                          ],
-                          "timeFrom": null,
-                          "timeShift": null,
-                          "title": "RPC Rate",
-                          "tooltip": {
-                              "shared": false,
-                              "sort": 0,
-                              "value_type": "individual"
-                          },
-                          "type": "graph",
-                          "xaxis": {
-                              "buckets": null,
-                              "mode": "time",
-                              "name": null,
-                              "show": true,
-                              "values": [
-
-                              ]
-                          },
-                          "yaxes": [
-                              {
-                                  "format": "ops",
-                                  "label": null,
-                                  "logBase": 1,
-                                  "max": null,
-                                  "min": null,
-                                  "show": true
-                              },
-                              {
-                                  "format": "ops",
-                                  "label": null,
-                                  "logBase": 1,
-                                  "max": null,
-                                  "min": null,
-                                  "show": true
-                              }
-                          ]
-                      },
-                      {
-                          "aliasColors": {
-
-                          },
-                          "bars": false,
-                          "dashLength": 10,
-                          "dashes": false,
-                          "datasource": "$datasource",
-                          "fill": 1,
-                          "gridPos": {
-
-                          },
-                          "id": 14,
-                          "legend": {
-                              "alignAsTable": true,
-                              "avg": false,
-                              "current": true,
-                              "max": false,
-                              "min": false,
-                              "rightSide": true,
-                              "show": true,
-                              "total": false,
-                              "values": true
-                          },
-                          "lines": true,
-                          "linewidth": 1,
-                          "links": [
-
-                          ],
-                          "nullPointMode": "null",
-                          "percentage": false,
-                          "pointradius": 5,
-                          "points": false,
-                          "renderer": "flot",
-                          "repeat": null,
-                          "seriesOverrides": [
-
-                          ],
-                          "spaceLength": 10,
-                          "span": 5,
-                          "stack": false,
-                          "steppedLine": false,
-                          "targets": [
-                              {
-                                  "expr": "histogram_quantile(0.99, sum(rate(apiserver_request_duration_seconds_bucket{job=\"apiserver\", instance=~\"$instance\", verb!=\"WATCH\", cluster=\"$cluster\"}[5m])) by (verb, le))",
-                                  "format": "time_series",
-                                  "intervalFactor": 2,
-                                  "legendFormat": "{{verb}}",
-                                  "refId": "A"
-                              }
-                          ],
-                          "thresholds": [
-
-                          ],
-                          "timeFrom": null,
-                          "timeShift": null,
-                          "title": "Request duration 99th quantile",
-                          "tooltip": {
-                              "shared": false,
-                              "sort": 0,
-                              "value_type": "individual"
-                          },
-                          "type": "graph",
-                          "xaxis": {
-                              "buckets": null,
-                              "mode": "time",
-                              "name": null,
-                              "show": true,
-                              "values": [
-
-                              ]
-                          },
-                          "yaxes": [
-                              {
-                                  "format": "s",
-                                  "label": null,
-                                  "logBase": 1,
-                                  "max": null,
-                                  "min": null,
-                                  "show": true
-                              },
-                              {
-                                  "format": "s",
-                                  "label": null,
-                                  "logBase": 1,
-                                  "max": null,
-                                  "min": null,
-                                  "show": true
-                              }
-                          ]
-                      }
-                  ],
-                  "repeat": null,
-                  "repeatIteration": null,
-                  "repeatRowId": null,
-                  "showTitle": false,
-                  "title": "Dashboard Row",
-                  "titleSize": "h6",
-                  "type": "row"
-              },
-              {
-                  "collapse": false,
-                  "collapsed": false,
-                  "panels": [
-                      {
-                          "aliasColors": {
-
-                          },
-                          "bars": false,
-                          "dashLength": 10,
-                          "dashes": false,
-                          "datasource": "$datasource",
-                          "fill": 1,
-                          "gridPos": {
-
-                          },
-                          "id": 15,
                           "legend": {
                               "alignAsTable": false,
                               "avg": false,
@@ -1284,6 +1031,7 @@ items:
                               "min": false,
                               "rightSide": false,
                               "show": false,
+                              "sideWidth": null,
                               "total": false,
                               "values": false
                           },
@@ -1302,7 +1050,7 @@ items:
 
                           ],
                           "spaceLength": 10,
-                          "span": 6,
+                          "span": 4,
                           "stack": false,
                           "steppedLine": false,
                           "targets": [
@@ -1366,7 +1114,7 @@ items:
                           "gridPos": {
 
                           },
-                          "id": 16,
+                          "id": 13,
                           "legend": {
                               "alignAsTable": false,
                               "avg": false,
@@ -1375,6 +1123,7 @@ items:
                               "min": false,
                               "rightSide": false,
                               "show": false,
+                              "sideWidth": null,
                               "total": false,
                               "values": false
                           },
@@ -1393,7 +1142,7 @@ items:
 
                           ],
                           "spaceLength": 10,
-                          "span": 6,
+                          "span": 4,
                           "stack": false,
                           "steppedLine": false,
                           "targets": [
@@ -1457,7 +1206,7 @@ items:
                           "gridPos": {
 
                           },
-                          "id": 17,
+                          "id": 14,
                           "legend": {
                               "alignAsTable": true,
                               "avg": false,
@@ -1466,6 +1215,7 @@ items:
                               "min": false,
                               "rightSide": true,
                               "show": true,
+                              "sideWidth": null,
                               "total": false,
                               "values": true
                           },
@@ -1484,7 +1234,7 @@ items:
 
                           ],
                           "spaceLength": 10,
-                          "span": 12,
+                          "span": 4,
                           "stack": false,
                           "steppedLine": false,
                           "targets": [
@@ -1561,7 +1311,7 @@ items:
                           "gridPos": {
 
                           },
-                          "id": 18,
+                          "id": 15,
                           "legend": {
                               "alignAsTable": false,
                               "avg": false,
@@ -1570,6 +1320,7 @@ items:
                               "min": false,
                               "rightSide": false,
                               "show": true,
+                              "sideWidth": null,
                               "total": false,
                               "values": false
                           },
@@ -1652,7 +1403,7 @@ items:
                           "gridPos": {
 
                           },
-                          "id": 19,
+                          "id": 16,
                           "legend": {
                               "alignAsTable": false,
                               "avg": false,
@@ -1661,6 +1412,7 @@ items:
                               "min": false,
                               "rightSide": false,
                               "show": true,
+                              "sideWidth": null,
                               "total": false,
                               "values": false
                           },
@@ -1750,7 +1502,7 @@ items:
                           "gridPos": {
 
                           },
-                          "id": 20,
+                          "id": 17,
                           "legend": {
                               "alignAsTable": false,
                               "avg": false,
@@ -1759,6 +1511,7 @@ items:
                               "min": false,
                               "rightSide": false,
                               "show": true,
+                              "sideWidth": null,
                               "total": false,
                               "values": false
                           },
@@ -1861,7 +1614,7 @@ items:
                           "gridPos": {
 
                           },
-                          "id": 21,
+                          "id": 18,
                           "legend": {
                               "alignAsTable": false,
                               "avg": false,
@@ -1870,6 +1623,7 @@ items:
                               "min": false,
                               "rightSide": false,
                               "show": true,
+                              "sideWidth": null,
                               "total": false,
                               "values": false
                           },
@@ -1952,7 +1706,7 @@ items:
                           "gridPos": {
 
                           },
-                          "id": 22,
+                          "id": 19,
                           "legend": {
                               "alignAsTable": false,
                               "avg": false,
@@ -1961,6 +1715,7 @@ items:
                               "min": false,
                               "rightSide": false,
                               "show": true,
+                              "sideWidth": null,
                               "total": false,
                               "values": false
                           },
@@ -2043,7 +1798,7 @@ items:
                           "gridPos": {
 
                           },
-                          "id": 23,
+                          "id": 20,
                           "legend": {
                               "alignAsTable": false,
                               "avg": false,
@@ -2052,6 +1807,7 @@ items:
                               "min": false,
                               "rightSide": false,
                               "show": true,
+                              "sideWidth": null,
                               "total": false,
                               "values": false
                           },
@@ -2327,6 +2083,7 @@ items:
                       "min": false,
                       "rightSide": true,
                       "show": true,
+                      "sideWidth": null,
                       "sort": "current",
                       "sortDesc": true,
                       "total": false,
@@ -2428,6 +2185,7 @@ items:
                       "min": false,
                       "rightSide": true,
                       "show": true,
+                      "sideWidth": null,
                       "sort": "current",
                       "sortDesc": true,
                       "total": false,
@@ -2867,6 +2625,7 @@ items:
                               "min": false,
                               "rightSide": true,
                               "show": true,
+                              "sideWidth": null,
                               "sort": "current",
                               "sortDesc": true,
                               "total": false,
@@ -2968,6 +2727,7 @@ items:
                               "min": false,
                               "rightSide": true,
                               "show": true,
+                              "sideWidth": null,
                               "sort": "current",
                               "sortDesc": true,
                               "total": false,
@@ -3099,6 +2859,7 @@ items:
                       "min": true,
                       "rightSide": true,
                       "show": true,
+                      "sideWidth": null,
                       "total": false,
                       "values": true
                   },
@@ -3198,6 +2959,7 @@ items:
                       "min": true,
                       "rightSide": true,
                       "show": true,
+                      "sideWidth": null,
                       "total": false,
                       "values": true
                   },
@@ -3308,6 +3070,7 @@ items:
                               "min": true,
                               "rightSide": true,
                               "show": true,
+                              "sideWidth": null,
                               "total": false,
                               "values": true
                           },
@@ -3407,6 +3170,7 @@ items:
                               "min": true,
                               "rightSide": true,
                               "show": true,
+                              "sideWidth": null,
                               "total": false,
                               "values": true
                           },
@@ -3526,6 +3290,7 @@ items:
                               "min": true,
                               "rightSide": true,
                               "show": true,
+                              "sideWidth": null,
                               "total": false,
                               "values": true
                           },
@@ -3625,6 +3390,7 @@ items:
                               "min": true,
                               "rightSide": true,
                               "show": true,
+                              "sideWidth": null,
                               "total": false,
                               "values": true
                           },
@@ -3724,6 +3490,7 @@ items:
                               "min": true,
                               "rightSide": true,
                               "show": true,
+                              "sideWidth": null,
                               "total": false,
                               "values": true
                           },
@@ -3827,6 +3594,7 @@ items:
                               "min": true,
                               "rightSide": true,
                               "show": true,
+                              "sideWidth": null,
                               "total": false,
                               "values": true
                           },
@@ -4195,6 +3963,7 @@ items:
                               "min": false,
                               "rightSide": true,
                               "show": true,
+                              "sideWidth": null,
                               "total": false,
                               "values": true
                           },
@@ -4299,6 +4068,7 @@ items:
                               "min": false,
                               "rightSide": true,
                               "show": true,
+                              "sideWidth": null,
                               "total": false,
                               "values": true
                           },
@@ -4403,6 +4173,7 @@ items:
                               "min": false,
                               "rightSide": true,
                               "show": true,
+                              "sideWidth": null,
                               "total": false,
                               "values": true
                           },
@@ -4507,6 +4278,7 @@ items:
                               "min": false,
                               "rightSide": false,
                               "show": true,
+                              "sideWidth": null,
                               "total": false,
                               "values": false
                           },
@@ -4619,6 +4391,7 @@ items:
                               "min": false,
                               "rightSide": false,
                               "show": true,
+                              "sideWidth": null,
                               "total": false,
                               "values": false
                           },
@@ -4723,6 +4496,7 @@ items:
                               "min": false,
                               "rightSide": true,
                               "show": true,
+                              "sideWidth": null,
                               "total": false,
                               "values": true
                           },
@@ -4827,6 +4601,7 @@ items:
                               "min": false,
                               "rightSide": false,
                               "show": true,
+                              "sideWidth": null,
                               "total": false,
                               "values": false
                           },
@@ -4918,6 +4693,7 @@ items:
                               "min": false,
                               "rightSide": false,
                               "show": true,
+                              "sideWidth": null,
                               "total": false,
                               "values": false
                           },
@@ -5009,6 +4785,7 @@ items:
                               "min": false,
                               "rightSide": false,
                               "show": true,
+                              "sideWidth": null,
                               "total": false,
                               "values": false
                           },
@@ -5211,6 +4988,7 @@ items:
                           "fill": 1,
                           "format": "percentunit",
                           "id": 1,
+                          "interval": "1m",
                           "legend": {
                               "avg": false,
                               "current": false,
@@ -6019,7 +5797,7 @@ items:
                           ],
                           "targets": [
                               {
-                                  "expr": "count(mixin_pod_workload{cluster=\"$cluster\"}) by (namespace)",
+                                  "expr": "sum(kube_pod_owner{cluster=\"$cluster\"}) by (namespace)",
                                   "format": "table",
                                   "instant": true,
                                   "intervalFactor": 2,
@@ -6438,7 +6216,7 @@ items:
                           ],
                           "targets": [
                               {
-                                  "expr": "count(mixin_pod_workload{cluster=\"$cluster\"}) by (namespace)",
+                                  "expr": "sum(kube_pod_owner{cluster=\"$cluster\"}) by (namespace)",
                                   "format": "table",
                                   "instant": true,
                                   "intervalFactor": 2,
@@ -6564,6 +6342,7 @@ items:
                           "datasource": "$datasource",
                           "fill": 1,
                           "id": 11,
+                          "interval": "1m",
                           "legend": {
                               "avg": false,
                               "current": false,
@@ -7651,33 +7430,6 @@ items:
                       "refresh": 1,
                       "regex": "",
                       "type": "datasource"
-                  },
-                  {
-                      "allValue": null,
-                      "current": {
-                          "text": "prod",
-                          "value": "prod"
-                      },
-                      "datasource": "$datasource",
-                      "hide": 2,
-                      "includeAll": false,
-                      "label": "cluster",
-                      "multi": false,
-                      "name": "cluster",
-                      "options": [
-
-                      ],
-                      "query": "label_values(node_cpu_seconds_total, cluster)",
-                      "refresh": 1,
-                      "regex": "",
-                      "sort": 2,
-                      "tagValuesQuery": "",
-                      "tags": [
-
-                      ],
-                      "tagsQuery": "",
-                      "type": "query",
-                      "useTags": false
                   },
                   {
                       "allValue": null,
@@ -9007,6 +8759,7 @@ items:
                           "datasource": "$datasource",
                           "fill": 1,
                           "id": 9,
+                          "interval": "1m",
                           "legend": {
                               "avg": false,
                               "current": false,
@@ -10053,7 +9806,7 @@ items:
                           "steppedLine": false,
                           "targets": [
                               {
-                                  "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{cluster=\"$cluster\", node=\"$node\"}) by (pod)",
+                                  "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{cluster=\"$cluster\", node=~\"$node\"}) by (pod)",
                                   "format": "time_series",
                                   "intervalFactor": 2,
                                   "legendFormat": "{{pod}}",
@@ -10282,7 +10035,7 @@ items:
                           ],
                           "targets": [
                               {
-                                  "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{cluster=\"$cluster\", node=\"$node\"}) by (pod)",
+                                  "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{cluster=\"$cluster\", node=~\"$node\"}) by (pod)",
                                   "format": "table",
                                   "instant": true,
                                   "intervalFactor": 2,
@@ -10291,7 +10044,7 @@ items:
                                   "step": 10
                               },
                               {
-                                  "expr": "sum(kube_pod_container_resource_requests_cpu_cores{cluster=\"$cluster\", node=\"$node\"}) by (pod)",
+                                  "expr": "sum(kube_pod_container_resource_requests_cpu_cores{cluster=\"$cluster\", node=~\"$node\"}) by (pod)",
                                   "format": "table",
                                   "instant": true,
                                   "intervalFactor": 2,
@@ -10300,7 +10053,7 @@ items:
                                   "step": 10
                               },
                               {
-                                  "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{cluster=\"$cluster\", node=\"$node\"}) by (pod) / sum(kube_pod_container_resource_requests_cpu_cores{cluster=\"$cluster\", node=\"$node\"}) by (pod)",
+                                  "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{cluster=\"$cluster\", node=~\"$node\"}) by (pod) / sum(kube_pod_container_resource_requests_cpu_cores{cluster=\"$cluster\", node=~\"$node\"}) by (pod)",
                                   "format": "table",
                                   "instant": true,
                                   "intervalFactor": 2,
@@ -10309,7 +10062,7 @@ items:
                                   "step": 10
                               },
                               {
-                                  "expr": "sum(kube_pod_container_resource_limits_cpu_cores{cluster=\"$cluster\", node=\"$node\"}) by (pod)",
+                                  "expr": "sum(kube_pod_container_resource_limits_cpu_cores{cluster=\"$cluster\", node=~\"$node\"}) by (pod)",
                                   "format": "table",
                                   "instant": true,
                                   "intervalFactor": 2,
@@ -10318,7 +10071,7 @@ items:
                                   "step": 10
                               },
                               {
-                                  "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{cluster=\"$cluster\", node=\"$node\"}) by (pod) / sum(kube_pod_container_resource_limits_cpu_cores{cluster=\"$cluster\", node=\"$node\"}) by (pod)",
+                                  "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{cluster=\"$cluster\", node=~\"$node\"}) by (pod) / sum(kube_pod_container_resource_limits_cpu_cores{cluster=\"$cluster\", node=~\"$node\"}) by (pod)",
                                   "format": "table",
                                   "instant": true,
                                   "intervalFactor": 2,
@@ -10418,7 +10171,7 @@ items:
                           "steppedLine": false,
                           "targets": [
                               {
-                                  "expr": "sum(node_namespace_pod_container:container_memory_working_set_bytes{cluster=\"$cluster\", node=\"$node\", container!=\"\"}) by (pod)",
+                                  "expr": "sum(node_namespace_pod_container:container_memory_working_set_bytes{cluster=\"$cluster\", node=~\"$node\", container!=\"\"}) by (pod)",
                                   "format": "time_series",
                                   "intervalFactor": 2,
                                   "legendFormat": "{{pod}}",
@@ -10701,7 +10454,7 @@ items:
                           ],
                           "targets": [
                               {
-                                  "expr": "sum(node_namespace_pod_container:container_memory_working_set_bytes{cluster=\"$cluster\", node=\"$node\",container!=\"\"}) by (pod)",
+                                  "expr": "sum(node_namespace_pod_container:container_memory_working_set_bytes{cluster=\"$cluster\", node=~\"$node\",container!=\"\"}) by (pod)",
                                   "format": "table",
                                   "instant": true,
                                   "intervalFactor": 2,
@@ -10710,7 +10463,7 @@ items:
                                   "step": 10
                               },
                               {
-                                  "expr": "sum(kube_pod_container_resource_requests_memory_bytes{cluster=\"$cluster\", node=\"$node\"}) by (pod)",
+                                  "expr": "sum(kube_pod_container_resource_requests_memory_bytes{cluster=\"$cluster\", node=~\"$node\"}) by (pod)",
                                   "format": "table",
                                   "instant": true,
                                   "intervalFactor": 2,
@@ -10719,7 +10472,7 @@ items:
                                   "step": 10
                               },
                               {
-                                  "expr": "sum(node_namespace_pod_container:container_memory_working_set_bytes{cluster=\"$cluster\", node=\"$node\",container!=\"\"}) by (pod) / sum(kube_pod_container_resource_requests_memory_bytes{node=\"$node\"}) by (pod)",
+                                  "expr": "sum(node_namespace_pod_container:container_memory_working_set_bytes{cluster=\"$cluster\", node=~\"$node\",container!=\"\"}) by (pod) / sum(kube_pod_container_resource_requests_memory_bytes{node=~\"$node\"}) by (pod)",
                                   "format": "table",
                                   "instant": true,
                                   "intervalFactor": 2,
@@ -10728,7 +10481,7 @@ items:
                                   "step": 10
                               },
                               {
-                                  "expr": "sum(kube_pod_container_resource_limits_memory_bytes{cluster=\"$cluster\", node=\"$node\"}) by (pod)",
+                                  "expr": "sum(kube_pod_container_resource_limits_memory_bytes{cluster=\"$cluster\", node=~\"$node\"}) by (pod)",
                                   "format": "table",
                                   "instant": true,
                                   "intervalFactor": 2,
@@ -10737,7 +10490,7 @@ items:
                                   "step": 10
                               },
                               {
-                                  "expr": "sum(node_namespace_pod_container:container_memory_working_set_bytes{cluster=\"$cluster\", node=\"$node\",container!=\"\"}) by (pod) / sum(kube_pod_container_resource_limits_memory_bytes{node=\"$node\"}) by (pod)",
+                                  "expr": "sum(node_namespace_pod_container:container_memory_working_set_bytes{cluster=\"$cluster\", node=~\"$node\",container!=\"\"}) by (pod) / sum(kube_pod_container_resource_limits_memory_bytes{node=~\"$node\"}) by (pod)",
                                   "format": "table",
                                   "instant": true,
                                   "intervalFactor": 2,
@@ -10746,7 +10499,7 @@ items:
                                   "step": 10
                               },
                               {
-                                  "expr": "sum(node_namespace_pod_container:container_memory_rss{cluster=\"$cluster\", node=\"$node\",container!=\"\"}) by (pod)",
+                                  "expr": "sum(node_namespace_pod_container:container_memory_rss{cluster=\"$cluster\", node=~\"$node\",container!=\"\"}) by (pod)",
                                   "format": "table",
                                   "instant": true,
                                   "intervalFactor": 2,
@@ -10755,7 +10508,7 @@ items:
                                   "step": 10
                               },
                               {
-                                  "expr": "sum(node_namespace_pod_container:container_memory_cache{cluster=\"$cluster\", node=\"$node\",container!=\"\"}) by (pod)",
+                                  "expr": "sum(node_namespace_pod_container:container_memory_cache{cluster=\"$cluster\", node=~\"$node\",container!=\"\"}) by (pod)",
                                   "format": "table",
                                   "instant": true,
                                   "intervalFactor": 2,
@@ -10764,7 +10517,7 @@ items:
                                   "step": 10
                               },
                               {
-                                  "expr": "sum(node_namespace_pod_container:container_memory_swap{cluster=\"$cluster\", node=\"$node\",container!=\"\"}) by (pod)",
+                                  "expr": "sum(node_namespace_pod_container:container_memory_swap{cluster=\"$cluster\", node=~\"$node\",container!=\"\"}) by (pod)",
                                   "format": "table",
                                   "instant": true,
                                   "intervalFactor": 2,
@@ -10883,7 +10636,7 @@ items:
                       "hide": 0,
                       "includeAll": false,
                       "label": null,
-                      "multi": false,
+                      "multi": true,
                       "name": "node",
                       "options": [
 
@@ -11956,6 +11709,7 @@ items:
                           "datasource": "$datasource",
                           "fill": 10,
                           "id": 6,
+                          "interval": "1m",
                           "legend": {
                               "avg": false,
                               "current": false,
@@ -12054,6 +11808,7 @@ items:
                           "datasource": "$datasource",
                           "fill": 10,
                           "id": 7,
+                          "interval": "1m",
                           "legend": {
                               "avg": false,
                               "current": false,
@@ -12152,6 +11907,7 @@ items:
                           "datasource": "$datasource",
                           "fill": 10,
                           "id": 8,
+                          "interval": "1m",
                           "legend": {
                               "avg": false,
                               "current": false,
@@ -12250,6 +12006,7 @@ items:
                           "datasource": "$datasource",
                           "fill": 10,
                           "id": 9,
+                          "interval": "1m",
                           "legend": {
                               "avg": false,
                               "current": false,
@@ -12348,6 +12105,7 @@ items:
                           "datasource": "$datasource",
                           "fill": 10,
                           "id": 10,
+                          "interval": "1m",
                           "legend": {
                               "avg": false,
                               "current": false,
@@ -12446,6 +12204,7 @@ items:
                           "datasource": "$datasource",
                           "fill": 10,
                           "id": 11,
+                          "interval": "1m",
                           "legend": {
                               "avg": false,
                               "current": false,
@@ -13437,6 +13196,7 @@ items:
                           "datasource": "$datasource",
                           "fill": 1,
                           "id": 5,
+                          "interval": "1m",
                           "legend": {
                               "avg": false,
                               "current": false,
@@ -15595,6 +15355,7 @@ items:
                           "datasource": "$datasource",
                           "fill": 1,
                           "id": 5,
+                          "interval": "1m",
                           "legend": {
                               "avg": false,
                               "current": false,
@@ -16621,7 +16382,7 @@ items:
                           "steppedLine": false,
                           "targets": [
                               {
-                                  "expr": "(sum(irate(container_network_transmit_packets_dropped_total{cluster=\"$cluster\", namespace=~\"$namespace\"}[$__interval])\n* on (namespace,pod) \ngroup_left(workload,workload_type) mixin_pod_workload{cluster=\"$cluster\", namespace=~\"$namespace\", workload=~\".+\", workload_type=\"$type\"}) by (workload))\n",
+                                  "expr": "(sum(irate(container_network_transmit_packets_dropped_total{cluster=\"$cluster\", namespace=~\"$namespace\"}[$__interval])\n* on (namespace,pod)\ngroup_left(workload,workload_type) mixin_pod_workload{cluster=\"$cluster\", namespace=~\"$namespace\", workload=~\".+\", workload_type=\"$type\"}) by (workload))\n",
                                   "format": "time_series",
                                   "intervalFactor": 2,
                                   "legendFormat": "{{workload}}",
@@ -17394,6 +17155,7 @@ items:
                               "min": false,
                               "rightSide": true,
                               "show": true,
+                              "sideWidth": null,
                               "total": false,
                               "values": true
                           },
@@ -17485,6 +17247,7 @@ items:
                               "min": false,
                               "rightSide": true,
                               "show": true,
+                              "sideWidth": null,
                               "total": false,
                               "values": true
                           },
@@ -17589,6 +17352,7 @@ items:
                               "min": false,
                               "rightSide": true,
                               "show": true,
+                              "sideWidth": null,
                               "total": false,
                               "values": true
                           },
@@ -17693,6 +17457,7 @@ items:
                               "min": false,
                               "rightSide": true,
                               "show": true,
+                              "sideWidth": null,
                               "total": false,
                               "values": true
                           },
@@ -17791,6 +17556,7 @@ items:
                               "min": false,
                               "rightSide": true,
                               "show": true,
+                              "sideWidth": null,
                               "total": false,
                               "values": true
                           },
@@ -17904,6 +17670,7 @@ items:
                               "min": false,
                               "rightSide": true,
                               "show": true,
+                              "sideWidth": null,
                               "total": false,
                               "values": true
                           },
@@ -17997,6 +17764,7 @@ items:
                               "min": false,
                               "rightSide": true,
                               "show": true,
+                              "sideWidth": null,
                               "total": false,
                               "values": true
                           },
@@ -18103,6 +17871,7 @@ items:
                               "min": false,
                               "rightSide": true,
                               "show": true,
+                              "sideWidth": null,
                               "total": false,
                               "values": true
                           },
@@ -18207,6 +17976,7 @@ items:
                               "min": false,
                               "rightSide": true,
                               "show": true,
+                              "sideWidth": null,
                               "total": false,
                               "values": true
                           },
@@ -18298,6 +18068,7 @@ items:
                               "min": false,
                               "rightSide": true,
                               "show": true,
+                              "sideWidth": null,
                               "total": false,
                               "values": true
                           },
@@ -18403,6 +18174,7 @@ items:
                               "min": false,
                               "rightSide": true,
                               "show": true,
+                              "sideWidth": null,
                               "total": false,
                               "values": true
                           },
@@ -18494,6 +18266,7 @@ items:
                               "min": false,
                               "rightSide": true,
                               "show": true,
+                              "sideWidth": null,
                               "total": false,
                               "values": true
                           },
@@ -18598,6 +18371,7 @@ items:
                               "min": false,
                               "rightSide": true,
                               "show": true,
+                              "sideWidth": null,
                               "total": false,
                               "values": true
                           },
@@ -18702,6 +18476,7 @@ items:
                               "min": false,
                               "rightSide": false,
                               "show": true,
+                              "sideWidth": null,
                               "total": false,
                               "values": false
                           },
@@ -18827,6 +18602,7 @@ items:
                               "min": false,
                               "rightSide": true,
                               "show": true,
+                              "sideWidth": null,
                               "total": false,
                               "values": true
                           },
@@ -18931,6 +18707,7 @@ items:
                               "min": false,
                               "rightSide": false,
                               "show": true,
+                              "sideWidth": null,
                               "total": false,
                               "values": false
                           },
@@ -19022,6 +18799,7 @@ items:
                               "min": false,
                               "rightSide": false,
                               "show": true,
+                              "sideWidth": null,
                               "total": false,
                               "values": false
                           },
@@ -19113,6 +18891,7 @@ items:
                               "min": false,
                               "rightSide": false,
                               "show": true,
+                              "sideWidth": null,
                               "total": false,
                               "values": false
                           },
@@ -19927,6 +19706,7 @@ items:
                       "min": false,
                       "rightSide": false,
                       "show": true,
+                      "sideWidth": null,
                       "total": false,
                       "values": false
                   },
@@ -20026,6 +19806,7 @@ items:
                       "min": false,
                       "rightSide": false,
                       "show": true,
+                      "sideWidth": null,
                       "total": false,
                       "values": false
                   },
@@ -20136,6 +19917,7 @@ items:
                               "min": false,
                               "rightSide": false,
                               "show": true,
+                              "sideWidth": null,
                               "total": false,
                               "values": false
                           },
@@ -20235,6 +20017,7 @@ items:
                               "min": false,
                               "rightSide": false,
                               "show": true,
+                              "sideWidth": null,
                               "total": false,
                               "values": false
                           },
@@ -20354,6 +20137,7 @@ items:
                               "min": false,
                               "rightSide": false,
                               "show": true,
+                              "sideWidth": null,
                               "total": false,
                               "values": false
                           },
@@ -20453,6 +20237,7 @@ items:
                               "min": false,
                               "rightSide": false,
                               "show": true,
+                              "sideWidth": null,
                               "total": false,
                               "values": false
                           },
@@ -20794,6 +20579,7 @@ items:
                       "min": false,
                       "rightSide": true,
                       "show": true,
+                      "sideWidth": null,
                       "sort": "current",
                       "sortDesc": true,
                       "total": false,
@@ -20895,6 +20681,7 @@ items:
                       "min": false,
                       "rightSide": true,
                       "show": true,
+                      "sideWidth": null,
                       "sort": "current",
                       "sortDesc": true,
                       "total": false,
@@ -21334,6 +21121,7 @@ items:
                               "min": false,
                               "rightSide": true,
                               "show": true,
+                              "sideWidth": null,
                               "sort": "current",
                               "sortDesc": true,
                               "total": false,
@@ -21435,6 +21223,7 @@ items:
                               "min": false,
                               "rightSide": true,
                               "show": true,
+                              "sideWidth": null,
                               "sort": "current",
                               "sortDesc": true,
                               "total": false,
@@ -21566,6 +21355,7 @@ items:
                       "min": false,
                       "rightSide": false,
                       "show": true,
+                      "sideWidth": null,
                       "total": false,
                       "values": false
                   },
@@ -21665,6 +21455,7 @@ items:
                       "min": false,
                       "rightSide": false,
                       "show": true,
+                      "sideWidth": null,
                       "total": false,
                       "values": false
                   },
@@ -21775,6 +21566,7 @@ items:
                               "min": false,
                               "rightSide": false,
                               "show": true,
+                              "sideWidth": null,
                               "total": false,
                               "values": false
                           },
@@ -21874,6 +21666,7 @@ items:
                               "min": false,
                               "rightSide": false,
                               "show": true,
+                              "sideWidth": null,
                               "total": false,
                               "values": false
                           },
@@ -21993,6 +21786,7 @@ items:
                               "min": false,
                               "rightSide": false,
                               "show": true,
+                              "sideWidth": null,
                               "total": false,
                               "values": false
                           },
@@ -22092,6 +21886,7 @@ items:
                               "min": false,
                               "rightSide": false,
                               "show": true,
+                              "sideWidth": null,
                               "total": false,
                               "values": false
                           },
@@ -24359,6 +24154,7 @@ items:
                               "min": false,
                               "rightSide": false,
                               "show": true,
+                              "sideWidth": null,
                               "total": false,
                               "values": false
                           },
@@ -24451,6 +24247,7 @@ items:
                               "min": false,
                               "rightSide": false,
                               "show": true,
+                              "sideWidth": null,
                               "total": false,
                               "values": false
                           },
@@ -24576,6 +24373,7 @@ items:
                               "min": false,
                               "rightSide": false,
                               "show": true,
+                              "sideWidth": null,
                               "total": false,
                               "values": false
                           },
@@ -24785,6 +24583,7 @@ items:
                               "min": false,
                               "rightSide": false,
                               "show": true,
+                              "sideWidth": null,
                               "total": false,
                               "values": false
                           },
@@ -24900,6 +24699,7 @@ items:
                               "min": false,
                               "rightSide": false,
                               "show": true,
+                              "sideWidth": null,
                               "total": false,
                               "values": false
                           },
@@ -25018,6 +24818,7 @@ items:
                               "min": false,
                               "rightSide": false,
                               "show": true,
+                              "sideWidth": null,
                               "total": false,
                               "values": false
                           },
@@ -25110,6 +24911,7 @@ items:
                               "min": false,
                               "rightSide": false,
                               "show": true,
+                              "sideWidth": null,
                               "total": false,
                               "values": false
                           },
@@ -25330,6 +25132,7 @@ items:
                               "min": true,
                               "rightSide": false,
                               "show": true,
+                              "sideWidth": null,
                               "total": false,
                               "values": true
                           },
@@ -25525,6 +25328,7 @@ items:
                               "min": true,
                               "rightSide": false,
                               "show": true,
+                              "sideWidth": null,
                               "total": false,
                               "values": true
                           },
@@ -26191,6 +25995,7 @@ items:
                       "min": false,
                       "rightSide": false,
                       "show": true,
+                      "sideWidth": null,
                       "total": false,
                       "values": false
                   },
@@ -26290,6 +26095,7 @@ items:
                       "min": false,
                       "rightSide": false,
                       "show": true,
+                      "sideWidth": null,
                       "total": false,
                       "values": false
                   },
@@ -26400,6 +26206,7 @@ items:
                               "min": false,
                               "rightSide": false,
                               "show": true,
+                              "sideWidth": null,
                               "total": false,
                               "values": false
                           },
@@ -26499,6 +26306,7 @@ items:
                               "min": false,
                               "rightSide": false,
                               "show": true,
+                              "sideWidth": null,
                               "total": false,
                               "values": false
                           },
@@ -26618,6 +26426,7 @@ items:
                               "min": false,
                               "rightSide": false,
                               "show": true,
+                              "sideWidth": null,
                               "total": false,
                               "values": false
                           },
@@ -26717,6 +26526,7 @@ items:
                               "min": false,
                               "rightSide": false,
                               "show": true,
+                              "sideWidth": null,
                               "total": false,
                               "values": false
                           },
@@ -27061,6 +26871,7 @@ items:
                               "min": false,
                               "rightSide": false,
                               "show": true,
+                              "sideWidth": null,
                               "total": false,
                               "values": false
                           },
@@ -27152,6 +26963,7 @@ items:
                               "min": false,
                               "rightSide": false,
                               "show": true,
+                              "sideWidth": null,
                               "total": false,
                               "values": false
                           },
@@ -27256,6 +27068,7 @@ items:
                               "min": false,
                               "rightSide": false,
                               "show": true,
+                              "sideWidth": null,
                               "total": false,
                               "values": false
                           },
@@ -27360,6 +27173,7 @@ items:
                               "min": false,
                               "rightSide": false,
                               "show": true,
+                              "sideWidth": null,
                               "total": false,
                               "values": false
                           },
@@ -27452,6 +27266,7 @@ items:
                               "min": false,
                               "rightSide": false,
                               "show": true,
+                              "sideWidth": null,
                               "total": false,
                               "values": false
                           },
@@ -27543,6 +27358,7 @@ items:
                               "min": false,
                               "rightSide": false,
                               "show": true,
+                              "sideWidth": null,
                               "total": false,
                               "values": false
                           },
@@ -27634,6 +27450,7 @@ items:
                               "min": false,
                               "rightSide": false,
                               "show": true,
+                              "sideWidth": null,
                               "total": false,
                               "values": false
                           },
@@ -27738,6 +27555,7 @@ items:
                               "min": false,
                               "rightSide": false,
                               "show": true,
+                              "sideWidth": null,
                               "total": false,
                               "values": false
                           },
@@ -27829,6 +27647,7 @@ items:
                               "min": false,
                               "rightSide": false,
                               "show": true,
+                              "sideWidth": null,
                               "total": false,
                               "values": false
                           },
@@ -27933,6 +27752,7 @@ items:
                               "min": false,
                               "rightSide": false,
                               "show": true,
+                              "sideWidth": null,
                               "total": false,
                               "values": false
                           },
@@ -28024,6 +27844,7 @@ items:
                               "min": false,
                               "rightSide": false,
                               "show": true,
+                              "sideWidth": null,
                               "total": false,
                               "values": false
                           },
@@ -28128,6 +27949,7 @@ items:
                               "min": false,
                               "rightSide": false,
                               "show": true,
+                              "sideWidth": null,
                               "total": false,
                               "values": false
                           },
@@ -28219,6 +28041,7 @@ items:
                               "min": false,
                               "rightSide": false,
                               "show": true,
+                              "sideWidth": null,
                               "total": false,
                               "values": false
                           },
@@ -28310,6 +28133,7 @@ items:
                               "min": false,
                               "rightSide": false,
                               "show": true,
+                              "sideWidth": null,
                               "total": false,
                               "values": false
                           },
@@ -28401,6 +28225,7 @@ items:
                               "min": false,
                               "rightSide": false,
                               "show": true,
+                              "sideWidth": null,
                               "total": false,
                               "values": false
                           },
@@ -29975,6 +29800,7 @@ items:
                               "min": false,
                               "rightSide": false,
                               "show": true,
+                              "sideWidth": null,
                               "total": false,
                               "values": false
                           },
@@ -30066,6 +29892,7 @@ items:
                               "min": false,
                               "rightSide": true,
                               "show": true,
+                              "sideWidth": null,
                               "total": false,
                               "values": true
                           },
@@ -30170,6 +29997,7 @@ items:
                               "min": false,
                               "rightSide": false,
                               "show": true,
+                              "sideWidth": null,
                               "total": false,
                               "values": false
                           },
@@ -30261,6 +30089,7 @@ items:
                               "min": false,
                               "rightSide": true,
                               "show": true,
+                              "sideWidth": null,
                               "total": false,
                               "values": true
                           },
@@ -30365,6 +30194,7 @@ items:
                               "min": false,
                               "rightSide": false,
                               "show": true,
+                              "sideWidth": null,
                               "total": false,
                               "values": false
                           },
@@ -30477,6 +30307,7 @@ items:
                               "min": false,
                               "rightSide": false,
                               "show": true,
+                              "sideWidth": null,
                               "total": false,
                               "values": false
                           },
@@ -30581,6 +30412,7 @@ items:
                               "min": false,
                               "rightSide": true,
                               "show": true,
+                              "sideWidth": null,
                               "total": false,
                               "values": true
                           },
@@ -30685,6 +30517,7 @@ items:
                               "min": false,
                               "rightSide": false,
                               "show": true,
+                              "sideWidth": null,
                               "total": false,
                               "values": false
                           },
@@ -30776,6 +30609,7 @@ items:
                               "min": false,
                               "rightSide": false,
                               "show": true,
+                              "sideWidth": null,
                               "total": false,
                               "values": false
                           },
@@ -30867,6 +30701,7 @@ items:
                               "min": false,
                               "rightSide": false,
                               "show": true,
+                              "sideWidth": null,
                               "total": false,
                               "values": false
                           },
@@ -31170,6 +31005,7 @@ items:
                               "min": false,
                               "rightSide": true,
                               "show": true,
+                              "sideWidth": null,
                               "total": false,
                               "values": true
                           },
@@ -31282,6 +31118,7 @@ items:
                               "min": false,
                               "rightSide": true,
                               "show": true,
+                              "sideWidth": null,
                               "total": false,
                               "values": true
                           },
@@ -31407,6 +31244,7 @@ items:
                               "min": false,
                               "rightSide": false,
                               "show": true,
+                              "sideWidth": null,
                               "total": false,
                               "values": false
                           },
@@ -31519,6 +31357,7 @@ items:
                               "min": false,
                               "rightSide": false,
                               "show": true,
+                              "sideWidth": null,
                               "total": false,
                               "values": false
                           },
@@ -31623,6 +31462,7 @@ items:
                               "min": false,
                               "rightSide": true,
                               "show": true,
+                              "sideWidth": null,
                               "total": false,
                               "values": true
                           },
@@ -31727,6 +31567,7 @@ items:
                               "min": false,
                               "rightSide": false,
                               "show": true,
+                              "sideWidth": null,
                               "total": false,
                               "values": false
                           },
@@ -31818,6 +31659,7 @@ items:
                               "min": false,
                               "rightSide": false,
                               "show": true,
+                              "sideWidth": null,
                               "total": false,
                               "values": false
                           },
@@ -31909,6 +31751,7 @@ items:
                               "min": false,
                               "rightSide": false,
                               "show": true,
+                              "sideWidth": null,
                               "total": false,
                               "values": false
                           },
@@ -32740,6 +32583,7 @@ items:
                               "min": false,
                               "rightSide": false,
                               "show": true,
+                              "sideWidth": null,
                               "total": false,
                               "values": false
                           },
@@ -33067,6 +32911,7 @@ items:
                       "min": false,
                       "rightSide": true,
                       "show": true,
+                      "sideWidth": null,
                       "sort": "current",
                       "sortDesc": true,
                       "total": false,
@@ -33168,6 +33013,7 @@ items:
                       "min": false,
                       "rightSide": true,
                       "show": true,
+                      "sideWidth": null,
                       "sort": "current",
                       "sortDesc": true,
                       "total": false,
@@ -33280,6 +33126,7 @@ items:
                               "min": false,
                               "rightSide": true,
                               "show": true,
+                              "sideWidth": null,
                               "sort": "current",
                               "sortDesc": true,
                               "total": false,
@@ -33381,6 +33228,7 @@ items:
                               "min": false,
                               "rightSide": true,
                               "show": true,
+                              "sideWidth": null,
                               "sort": "current",
                               "sortDesc": true,
                               "total": false,
@@ -33512,6 +33360,7 @@ items:
                       "min": false,
                       "rightSide": false,
                       "show": true,
+                      "sideWidth": null,
                       "total": false,
                       "values": false
                   },
@@ -33611,6 +33460,7 @@ items:
                       "min": false,
                       "rightSide": false,
                       "show": true,
+                      "sideWidth": null,
                       "total": false,
                       "values": false
                   },
@@ -33721,6 +33571,7 @@ items:
                               "min": false,
                               "rightSide": false,
                               "show": true,
+                              "sideWidth": null,
                               "total": false,
                               "values": false
                           },
@@ -33820,6 +33671,7 @@ items:
                               "min": false,
                               "rightSide": false,
                               "show": true,
+                              "sideWidth": null,
                               "total": false,
                               "values": false
                           },
@@ -33939,6 +33791,7 @@ items:
                               "min": false,
                               "rightSide": false,
                               "show": true,
+                              "sideWidth": null,
                               "total": false,
                               "values": false
                           },
@@ -34038,6 +33891,7 @@ items:
                               "min": false,
                               "rightSide": false,
                               "show": true,
+                              "sideWidth": null,
                               "total": false,
                               "values": false
                           },

--- a/manifests/prometheus-adapter-deployment.yaml
+++ b/manifests/prometheus-adapter-deployment.yaml
@@ -23,7 +23,7 @@ spec:
         - --config=/etc/adapter/config.yaml
         - --logtostderr=true
         - --metrics-relist-interval=1m
-        - --prometheus-url=http://prometheus-k8s.monitoring.svc:9090/
+        - --prometheus-url=http://prometheus-k8s.monitoring.svc.cluster.local:9090/
         - --secure-port=6443
         image: quay.io/coreos/k8s-prometheus-adapter-amd64:v0.7.0
         name: prometheus-adapter

--- a/manifests/prometheus-rules.yaml
+++ b/manifests/prometheus-rules.yaml
@@ -74,7 +74,7 @@ spec:
             sum(rate(apiserver_request_duration_seconds_count{job="apiserver",verb=~"LIST|GET"}[1d]))
             -
             (
-              sum(rate(apiserver_request_duration_seconds_bucket{job="apiserver",verb=~"LIST|GET",scope="resource",le="0.1"}[1d])) +
+              sum(rate(apiserver_request_duration_seconds_bucket{job="apiserver",verb=~"LIST|GET",scope=~"resource|",le="0.1"}[1d])) +
               sum(rate(apiserver_request_duration_seconds_bucket{job="apiserver",verb=~"LIST|GET",scope="namespace",le="0.5"}[1d])) +
               sum(rate(apiserver_request_duration_seconds_bucket{job="apiserver",verb=~"LIST|GET",scope="cluster",le="5"}[1d]))
             )
@@ -95,7 +95,7 @@ spec:
             sum(rate(apiserver_request_duration_seconds_count{job="apiserver",verb=~"LIST|GET"}[1h]))
             -
             (
-              sum(rate(apiserver_request_duration_seconds_bucket{job="apiserver",verb=~"LIST|GET",scope="resource",le="0.1"}[1h])) +
+              sum(rate(apiserver_request_duration_seconds_bucket{job="apiserver",verb=~"LIST|GET",scope=~"resource|",le="0.1"}[1h])) +
               sum(rate(apiserver_request_duration_seconds_bucket{job="apiserver",verb=~"LIST|GET",scope="namespace",le="0.5"}[1h])) +
               sum(rate(apiserver_request_duration_seconds_bucket{job="apiserver",verb=~"LIST|GET",scope="cluster",le="5"}[1h]))
             )
@@ -116,7 +116,7 @@ spec:
             sum(rate(apiserver_request_duration_seconds_count{job="apiserver",verb=~"LIST|GET"}[2h]))
             -
             (
-              sum(rate(apiserver_request_duration_seconds_bucket{job="apiserver",verb=~"LIST|GET",scope="resource",le="0.1"}[2h])) +
+              sum(rate(apiserver_request_duration_seconds_bucket{job="apiserver",verb=~"LIST|GET",scope=~"resource|",le="0.1"}[2h])) +
               sum(rate(apiserver_request_duration_seconds_bucket{job="apiserver",verb=~"LIST|GET",scope="namespace",le="0.5"}[2h])) +
               sum(rate(apiserver_request_duration_seconds_bucket{job="apiserver",verb=~"LIST|GET",scope="cluster",le="5"}[2h]))
             )
@@ -137,7 +137,7 @@ spec:
             sum(rate(apiserver_request_duration_seconds_count{job="apiserver",verb=~"LIST|GET"}[30m]))
             -
             (
-              sum(rate(apiserver_request_duration_seconds_bucket{job="apiserver",verb=~"LIST|GET",scope="resource",le="0.1"}[30m])) +
+              sum(rate(apiserver_request_duration_seconds_bucket{job="apiserver",verb=~"LIST|GET",scope=~"resource|",le="0.1"}[30m])) +
               sum(rate(apiserver_request_duration_seconds_bucket{job="apiserver",verb=~"LIST|GET",scope="namespace",le="0.5"}[30m])) +
               sum(rate(apiserver_request_duration_seconds_bucket{job="apiserver",verb=~"LIST|GET",scope="cluster",le="5"}[30m]))
             )
@@ -158,7 +158,7 @@ spec:
             sum(rate(apiserver_request_duration_seconds_count{job="apiserver",verb=~"LIST|GET"}[3d]))
             -
             (
-              sum(rate(apiserver_request_duration_seconds_bucket{job="apiserver",verb=~"LIST|GET",scope="resource",le="0.1"}[3d])) +
+              sum(rate(apiserver_request_duration_seconds_bucket{job="apiserver",verb=~"LIST|GET",scope=~"resource|",le="0.1"}[3d])) +
               sum(rate(apiserver_request_duration_seconds_bucket{job="apiserver",verb=~"LIST|GET",scope="namespace",le="0.5"}[3d])) +
               sum(rate(apiserver_request_duration_seconds_bucket{job="apiserver",verb=~"LIST|GET",scope="cluster",le="5"}[3d]))
             )
@@ -179,7 +179,7 @@ spec:
             sum(rate(apiserver_request_duration_seconds_count{job="apiserver",verb=~"LIST|GET"}[5m]))
             -
             (
-              sum(rate(apiserver_request_duration_seconds_bucket{job="apiserver",verb=~"LIST|GET",scope="resource",le="0.1"}[5m])) +
+              sum(rate(apiserver_request_duration_seconds_bucket{job="apiserver",verb=~"LIST|GET",scope=~"resource|",le="0.1"}[5m])) +
               sum(rate(apiserver_request_duration_seconds_bucket{job="apiserver",verb=~"LIST|GET",scope="namespace",le="0.5"}[5m])) +
               sum(rate(apiserver_request_duration_seconds_bucket{job="apiserver",verb=~"LIST|GET",scope="cluster",le="5"}[5m]))
             )
@@ -200,7 +200,7 @@ spec:
             sum(rate(apiserver_request_duration_seconds_count{job="apiserver",verb=~"LIST|GET"}[6h]))
             -
             (
-              sum(rate(apiserver_request_duration_seconds_bucket{job="apiserver",verb=~"LIST|GET",scope="resource",le="0.1"}[6h])) +
+              sum(rate(apiserver_request_duration_seconds_bucket{job="apiserver",verb=~"LIST|GET",scope=~"resource|",le="0.1"}[6h])) +
               sum(rate(apiserver_request_duration_seconds_bucket{job="apiserver",verb=~"LIST|GET",scope="namespace",le="0.5"}[6h])) +
               sum(rate(apiserver_request_duration_seconds_bucket{job="apiserver",verb=~"LIST|GET",scope="cluster",le="5"}[6h]))
             )
@@ -327,81 +327,6 @@ spec:
         verb: write
       record: apiserver_request:burnrate6h
     - expr: |
-        1 - (
-          (
-            # write too slow
-            sum(increase(apiserver_request_duration_seconds_count{verb=~"POST|PUT|PATCH|DELETE"}[30d]))
-            -
-            sum(increase(apiserver_request_duration_seconds_bucket{verb=~"POST|PUT|PATCH|DELETE",le="1"}[30d]))
-          ) +
-          (
-            # read too slow
-            sum(increase(apiserver_request_duration_seconds_count{verb=~"LIST|GET"}[30d]))
-            -
-            (
-              sum(increase(apiserver_request_duration_seconds_bucket{verb=~"LIST|GET",scope="resource",le="0.1"}[30d])) +
-              sum(increase(apiserver_request_duration_seconds_bucket{verb=~"LIST|GET",scope="namespace",le="0.5"}[30d])) +
-              sum(increase(apiserver_request_duration_seconds_bucket{verb=~"LIST|GET",scope="cluster",le="5"}[30d]))
-            )
-          ) +
-          # errors
-          sum(code:apiserver_request_total:increase30d{code=~"5.."})
-        )
-        /
-        sum(code:apiserver_request_total:increase30d)
-      labels:
-        verb: all
-      record: apiserver_request:availability30d
-    - expr: |
-        1 - (
-          sum(increase(apiserver_request_duration_seconds_count{job="apiserver",verb=~"LIST|GET"}[30d]))
-          -
-          (
-            # too slow
-            sum(increase(apiserver_request_duration_seconds_bucket{job="apiserver",verb=~"LIST|GET",scope="resource",le="0.1"}[30d])) +
-            sum(increase(apiserver_request_duration_seconds_bucket{job="apiserver",verb=~"LIST|GET",scope="namespace",le="0.5"}[30d])) +
-            sum(increase(apiserver_request_duration_seconds_bucket{job="apiserver",verb=~"LIST|GET",scope="cluster",le="5"}[30d]))
-          )
-          +
-          # errors
-          sum(code:apiserver_request_total:increase30d{verb="read",code=~"5.."})
-        )
-        /
-        sum(code:apiserver_request_total:increase30d{verb="read"})
-      labels:
-        verb: read
-      record: apiserver_request:availability30d
-    - expr: |
-        1 - (
-          (
-            # too slow
-            sum(increase(apiserver_request_duration_seconds_count{verb=~"POST|PUT|PATCH|DELETE"}[30d]))
-            -
-            sum(increase(apiserver_request_duration_seconds_bucket{verb=~"POST|PUT|PATCH|DELETE",le="1"}[30d]))
-          )
-          +
-          # errors
-          sum(code:apiserver_request_total:increase30d{verb="write",code=~"5.."})
-        )
-        /
-        sum(code:apiserver_request_total:increase30d{verb="write"})
-      labels:
-        verb: write
-      record: apiserver_request:availability30d
-    - expr: |
-        sum by (code, verb) (increase(apiserver_request_total{job="apiserver"}[30d]))
-      record: code_verb:apiserver_request_total:increase30d
-    - expr: |
-        sum by (code) (code_verb:apiserver_request_total:increase30d{verb=~"LIST|GET"})
-      labels:
-        verb: read
-      record: code:apiserver_request_total:increase30d
-    - expr: |
-        sum by (code) (code_verb:apiserver_request_total:increase30d{verb=~"POST|PUT|PATCH|DELETE"})
-      labels:
-        verb: write
-      record: code:apiserver_request_total:increase30d
-    - expr: |
         sum by (code,resource) (rate(apiserver_request_total{job="apiserver",verb=~"LIST|GET"}[5m]))
       labels:
         verb: read
@@ -443,6 +368,153 @@ spec:
       labels:
         quantile: "0.5"
       record: cluster_quantile:apiserver_request_duration_seconds:histogram_quantile
+  - interval: 3m
+    name: kube-apiserver-availability.rules
+    rules:
+    - expr: |
+        1 - (
+          (
+            # write too slow
+            sum(increase(apiserver_request_duration_seconds_count{verb=~"POST|PUT|PATCH|DELETE"}[30d]))
+            -
+            sum(increase(apiserver_request_duration_seconds_bucket{verb=~"POST|PUT|PATCH|DELETE",le="1"}[30d]))
+          ) +
+          (
+            # read too slow
+            sum(increase(apiserver_request_duration_seconds_count{verb=~"LIST|GET"}[30d]))
+            -
+            (
+              sum(increase(apiserver_request_duration_seconds_bucket{verb=~"LIST|GET",scope=~"resource|",le="0.1"}[30d])) +
+              sum(increase(apiserver_request_duration_seconds_bucket{verb=~"LIST|GET",scope="namespace",le="0.5"}[30d])) +
+              sum(increase(apiserver_request_duration_seconds_bucket{verb=~"LIST|GET",scope="cluster",le="5"}[30d]))
+            )
+          ) +
+          # errors
+          sum(code:apiserver_request_total:increase30d{code=~"5.."} or vector(0))
+        )
+        /
+        sum(code:apiserver_request_total:increase30d)
+      labels:
+        verb: all
+      record: apiserver_request:availability30d
+    - expr: |
+        1 - (
+          sum(increase(apiserver_request_duration_seconds_count{job="apiserver",verb=~"LIST|GET"}[30d]))
+          -
+          (
+            # too slow
+            sum(increase(apiserver_request_duration_seconds_bucket{job="apiserver",verb=~"LIST|GET",scope=~"resource|",le="0.1"}[30d])) +
+            sum(increase(apiserver_request_duration_seconds_bucket{job="apiserver",verb=~"LIST|GET",scope="namespace",le="0.5"}[30d])) +
+            sum(increase(apiserver_request_duration_seconds_bucket{job="apiserver",verb=~"LIST|GET",scope="cluster",le="5"}[30d]))
+          )
+          +
+          # errors
+          sum(code:apiserver_request_total:increase30d{verb="read",code=~"5.."} or vector(0))
+        )
+        /
+        sum(code:apiserver_request_total:increase30d{verb="read"})
+      labels:
+        verb: read
+      record: apiserver_request:availability30d
+    - expr: |
+        1 - (
+          (
+            # too slow
+            sum(increase(apiserver_request_duration_seconds_count{verb=~"POST|PUT|PATCH|DELETE"}[30d]))
+            -
+            sum(increase(apiserver_request_duration_seconds_bucket{verb=~"POST|PUT|PATCH|DELETE",le="1"}[30d]))
+          )
+          +
+          # errors
+          sum(code:apiserver_request_total:increase30d{verb="write",code=~"5.."} or vector(0))
+        )
+        /
+        sum(code:apiserver_request_total:increase30d{verb="write"})
+      labels:
+        verb: write
+      record: apiserver_request:availability30d
+    - expr: |
+        sum by (code, verb) (increase(apiserver_request_total{job="apiserver",verb="LIST",code=~"2.."}[30d]))
+      record: code_verb:apiserver_request_total:increase30d
+    - expr: |
+        sum by (code, verb) (increase(apiserver_request_total{job="apiserver",verb="GET",code=~"2.."}[30d]))
+      record: code_verb:apiserver_request_total:increase30d
+    - expr: |
+        sum by (code, verb) (increase(apiserver_request_total{job="apiserver",verb="POST",code=~"2.."}[30d]))
+      record: code_verb:apiserver_request_total:increase30d
+    - expr: |
+        sum by (code, verb) (increase(apiserver_request_total{job="apiserver",verb="PUT",code=~"2.."}[30d]))
+      record: code_verb:apiserver_request_total:increase30d
+    - expr: |
+        sum by (code, verb) (increase(apiserver_request_total{job="apiserver",verb="PATCH",code=~"2.."}[30d]))
+      record: code_verb:apiserver_request_total:increase30d
+    - expr: |
+        sum by (code, verb) (increase(apiserver_request_total{job="apiserver",verb="DELETE",code=~"2.."}[30d]))
+      record: code_verb:apiserver_request_total:increase30d
+    - expr: |
+        sum by (code, verb) (increase(apiserver_request_total{job="apiserver",verb="LIST",code=~"3.."}[30d]))
+      record: code_verb:apiserver_request_total:increase30d
+    - expr: |
+        sum by (code, verb) (increase(apiserver_request_total{job="apiserver",verb="GET",code=~"3.."}[30d]))
+      record: code_verb:apiserver_request_total:increase30d
+    - expr: |
+        sum by (code, verb) (increase(apiserver_request_total{job="apiserver",verb="POST",code=~"3.."}[30d]))
+      record: code_verb:apiserver_request_total:increase30d
+    - expr: |
+        sum by (code, verb) (increase(apiserver_request_total{job="apiserver",verb="PUT",code=~"3.."}[30d]))
+      record: code_verb:apiserver_request_total:increase30d
+    - expr: |
+        sum by (code, verb) (increase(apiserver_request_total{job="apiserver",verb="PATCH",code=~"3.."}[30d]))
+      record: code_verb:apiserver_request_total:increase30d
+    - expr: |
+        sum by (code, verb) (increase(apiserver_request_total{job="apiserver",verb="DELETE",code=~"3.."}[30d]))
+      record: code_verb:apiserver_request_total:increase30d
+    - expr: |
+        sum by (code, verb) (increase(apiserver_request_total{job="apiserver",verb="LIST",code=~"4.."}[30d]))
+      record: code_verb:apiserver_request_total:increase30d
+    - expr: |
+        sum by (code, verb) (increase(apiserver_request_total{job="apiserver",verb="GET",code=~"4.."}[30d]))
+      record: code_verb:apiserver_request_total:increase30d
+    - expr: |
+        sum by (code, verb) (increase(apiserver_request_total{job="apiserver",verb="POST",code=~"4.."}[30d]))
+      record: code_verb:apiserver_request_total:increase30d
+    - expr: |
+        sum by (code, verb) (increase(apiserver_request_total{job="apiserver",verb="PUT",code=~"4.."}[30d]))
+      record: code_verb:apiserver_request_total:increase30d
+    - expr: |
+        sum by (code, verb) (increase(apiserver_request_total{job="apiserver",verb="PATCH",code=~"4.."}[30d]))
+      record: code_verb:apiserver_request_total:increase30d
+    - expr: |
+        sum by (code, verb) (increase(apiserver_request_total{job="apiserver",verb="DELETE",code=~"4.."}[30d]))
+      record: code_verb:apiserver_request_total:increase30d
+    - expr: |
+        sum by (code, verb) (increase(apiserver_request_total{job="apiserver",verb="LIST",code=~"5.."}[30d]))
+      record: code_verb:apiserver_request_total:increase30d
+    - expr: |
+        sum by (code, verb) (increase(apiserver_request_total{job="apiserver",verb="GET",code=~"5.."}[30d]))
+      record: code_verb:apiserver_request_total:increase30d
+    - expr: |
+        sum by (code, verb) (increase(apiserver_request_total{job="apiserver",verb="POST",code=~"5.."}[30d]))
+      record: code_verb:apiserver_request_total:increase30d
+    - expr: |
+        sum by (code, verb) (increase(apiserver_request_total{job="apiserver",verb="PUT",code=~"5.."}[30d]))
+      record: code_verb:apiserver_request_total:increase30d
+    - expr: |
+        sum by (code, verb) (increase(apiserver_request_total{job="apiserver",verb="PATCH",code=~"5.."}[30d]))
+      record: code_verb:apiserver_request_total:increase30d
+    - expr: |
+        sum by (code, verb) (increase(apiserver_request_total{job="apiserver",verb="DELETE",code=~"5.."}[30d]))
+      record: code_verb:apiserver_request_total:increase30d
+    - expr: |
+        sum by (code) (code_verb:apiserver_request_total:increase30d{verb=~"LIST|GET"})
+      labels:
+        verb: read
+      record: code:apiserver_request_total:increase30d
+    - expr: |
+        sum by (code) (code_verb:apiserver_request_total:increase30d{verb=~"POST|PUT|PATCH|DELETE"})
+      labels:
+        verb: write
+      record: code:apiserver_request_total:increase30d
   - name: k8s.rules
     rules:
     - expr: |
@@ -452,31 +524,31 @@ spec:
         sum by (cluster, namespace, pod, container) (
           rate(container_cpu_usage_seconds_total{job="kubelet", metrics_path="/metrics/cadvisor", image!="", container!="POD"}[5m])
         ) * on (cluster, namespace, pod) group_left(node) topk by (cluster, namespace, pod) (
-          1, max by(cluster, namespace, pod, node) (kube_pod_info)
+          1, max by(cluster, namespace, pod, node) (kube_pod_info{node!=""})
         )
       record: node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate
     - expr: |
         container_memory_working_set_bytes{job="kubelet", metrics_path="/metrics/cadvisor", image!=""}
         * on (namespace, pod) group_left(node) topk by(namespace, pod) (1,
-          max by(namespace, pod, node) (kube_pod_info)
+          max by(namespace, pod, node) (kube_pod_info{node!=""})
         )
       record: node_namespace_pod_container:container_memory_working_set_bytes
     - expr: |
         container_memory_rss{job="kubelet", metrics_path="/metrics/cadvisor", image!=""}
         * on (namespace, pod) group_left(node) topk by(namespace, pod) (1,
-          max by(namespace, pod, node) (kube_pod_info)
+          max by(namespace, pod, node) (kube_pod_info{node!=""})
         )
       record: node_namespace_pod_container:container_memory_rss
     - expr: |
         container_memory_cache{job="kubelet", metrics_path="/metrics/cadvisor", image!=""}
         * on (namespace, pod) group_left(node) topk by(namespace, pod) (1,
-          max by(namespace, pod, node) (kube_pod_info)
+          max by(namespace, pod, node) (kube_pod_info{node!=""})
         )
       record: node_namespace_pod_container:container_memory_cache
     - expr: |
         container_memory_swap{job="kubelet", metrics_path="/metrics/cadvisor", image!=""}
         * on (namespace, pod) group_left(node) topk by(namespace, pod) (1,
-          max by(namespace, pod, node) (kube_pod_info)
+          max by(namespace, pod, node) (kube_pod_info{node!=""})
         )
       record: node_namespace_pod_container:container_memory_swap
     - expr: |
@@ -591,12 +663,12 @@ spec:
   - name: node.rules
     rules:
     - expr: |
-        sum(min(kube_pod_info) by (cluster, node))
+        sum(min(kube_pod_info{node!=""}) by (cluster, node))
       record: ':kube_pod_info_node_count:'
     - expr: |
         topk by(namespace, pod) (1,
           max by (node, namespace, pod) (
-            label_replace(kube_pod_info{job="kube-state-metrics"}, "pod", "$1", "pod", "(.*)")
+            label_replace(kube_pod_info{job="kube-state-metrics",node!=""}, "pod", "$1", "pod", "(.*)")
         ))
       record: 'node_namespace_pod:kube_pod_info:'
     - expr: |
@@ -849,11 +921,20 @@ spec:
         severity: warning
     - alert: NodeHighNumberConntrackEntriesUsed
       annotations:
-        description: '{{ $value | humanizePercentage }} of conntrack entries are used'
+        description: '{{ $value | humanizePercentage }} of conntrack entries are used.'
         runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-nodehighnumberconntrackentriesused
-        summary: Number of conntrack are getting close to the limit
+        summary: Number of conntrack are getting close to the limit.
       expr: |
         (node_nf_conntrack_entries / node_nf_conntrack_entries_limit) > 0.75
+      labels:
+        severity: warning
+    - alert: NodeTextFileCollectorScrapeError
+      annotations:
+        description: Node Exporter text file collector failed to scrape.
+        runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-nodetextfilecollectorscrapeerror
+        summary: Node Exporter text file collector failed to scrape.
+      expr: |
+        node_textfile_scrape_error{job="node-exporter"} == 1
       labels:
         severity: warning
     - alert: NodeClockSkewDetected
@@ -896,20 +977,26 @@ spec:
           }}) is restarting {{ printf "%.2f" $value }} times / 5 minutes.
         runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepodcrashlooping
       expr: |
-        rate(kube_pod_container_status_restarts_total{job="kube-state-metrics"}[15m]) * 60 * 5 > 0
+        rate(kube_pod_container_status_restarts_total{job="kube-state-metrics"}[5m]) * 60 * 5 > 0
       for: 15m
       labels:
-        severity: critical
+        severity: warning
     - alert: KubePodNotReady
       annotations:
         message: Pod {{ $labels.namespace }}/{{ $labels.pod }} has been in a non-ready
           state for longer than 15 minutes.
         runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepodnotready
       expr: |
-        sum by (namespace, pod) (max by(namespace, pod) (kube_pod_status_phase{job="kube-state-metrics", phase=~"Pending|Unknown"}) * on(namespace, pod) group_left(owner_kind) max by(namespace, pod, owner_kind) (kube_pod_owner{owner_kind!="Job"})) > 0
+        sum by (namespace, pod) (
+          max by(namespace, pod) (
+            kube_pod_status_phase{job="kube-state-metrics", phase=~"Pending|Unknown"}
+          ) * on(namespace, pod) group_left(owner_kind) topk by(namespace, pod) (
+            1, max by(namespace, pod, owner_kind) (kube_pod_owner{owner_kind!="Job"})
+          )
+        ) > 0
       for: 15m
       labels:
-        severity: critical
+        severity: warning
     - alert: KubeDeploymentGenerationMismatch
       annotations:
         message: Deployment generation for {{ $labels.namespace }}/{{ $labels.deployment
@@ -922,7 +1009,7 @@ spec:
         kube_deployment_metadata_generation{job="kube-state-metrics"}
       for: 15m
       labels:
-        severity: critical
+        severity: warning
     - alert: KubeDeploymentReplicasMismatch
       annotations:
         message: Deployment {{ $labels.namespace }}/{{ $labels.deployment }} has not
@@ -940,7 +1027,7 @@ spec:
         )
       for: 15m
       labels:
-        severity: critical
+        severity: warning
     - alert: KubeStatefulSetReplicasMismatch
       annotations:
         message: StatefulSet {{ $labels.namespace }}/{{ $labels.statefulset }} has
@@ -958,7 +1045,7 @@ spec:
         )
       for: 15m
       labels:
-        severity: critical
+        severity: warning
     - alert: KubeStatefulSetGenerationMismatch
       annotations:
         message: StatefulSet generation for {{ $labels.namespace }}/{{ $labels.statefulset
@@ -971,7 +1058,7 @@ spec:
         kube_statefulset_metadata_generation{job="kube-state-metrics"}
       for: 15m
       labels:
-        severity: critical
+        severity: warning
     - alert: KubeStatefulSetUpdateNotRolledOut
       annotations:
         message: StatefulSet {{ $labels.namespace }}/{{ $labels.statefulset }} update
@@ -991,7 +1078,7 @@ spec:
         )
       for: 15m
       labels:
-        severity: critical
+        severity: warning
     - alert: KubeDaemonSetRolloutStuck
       annotations:
         message: Only {{ $value | humanizePercentage }} of the desired Pods of DaemonSet
@@ -1003,7 +1090,7 @@ spec:
         kube_daemonset_status_desired_number_scheduled{job="kube-state-metrics"} < 1.00
       for: 15m
       labels:
-        severity: critical
+        severity: warning
     - alert: KubeContainerWaiting
       annotations:
         message: Pod {{ $labels.namespace }}/{{ $labels.pod }} container {{ $labels.container}}
@@ -1254,7 +1341,9 @@ spec:
         sum(apiserver_request:burnrate5m) > (14.40 * 0.01000)
       for: 2m
       labels:
+        long: 1h
         severity: critical
+        short: 5m
     - alert: KubeAPIErrorBudgetBurn
       annotations:
         message: The API server is burning too much error budget
@@ -1265,7 +1354,9 @@ spec:
         sum(apiserver_request:burnrate30m) > (6.00 * 0.01000)
       for: 15m
       labels:
+        long: 6h
         severity: critical
+        short: 30m
     - alert: KubeAPIErrorBudgetBurn
       annotations:
         message: The API server is burning too much error budget
@@ -1276,7 +1367,9 @@ spec:
         sum(apiserver_request:burnrate2h) > (3.00 * 0.01000)
       for: 1h
       labels:
+        long: 1d
         severity: warning
+        short: 2h
     - alert: KubeAPIErrorBudgetBurn
       annotations:
         message: The API server is burning too much error budget
@@ -1287,7 +1380,9 @@ spec:
         sum(apiserver_request:burnrate6h) > (1.00 * 0.01000)
       for: 3h
       labels:
+        long: 3d
         severity: warning
+        short: 6h
   - name: kubernetes-system-apiserver
     rules:
     - alert: KubeAPILatencyHigh
@@ -1296,6 +1391,10 @@ spec:
           {{ $labels.verb }} {{ $labels.resource }}.
         runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeapilatencyhigh
       expr: |
+        cluster_quantile:apiserver_request_duration_seconds:histogram_quantile{job="apiserver",quantile="0.99"}
+        >
+        1
+        and on (verb,resource)
         (
           cluster:apiserver_request_duration_seconds:mean5m{job="apiserver"}
           >
@@ -1307,10 +1406,6 @@ spec:
           )
         ) > on (verb) group_left()
         1.2 * avg by (verb) (cluster:apiserver_request_duration_seconds:mean5m{job="apiserver"} >= 0)
-        and on (verb,resource)
-        cluster_quantile:apiserver_request_duration_seconds:histogram_quantile{job="apiserver",quantile="0.99"}
-        >
-        1
       for: 5m
       labels:
         severity: warning
@@ -1391,8 +1486,7 @@ spec:
         message: '{{ $labels.node }} is unreachable and some workloads may be rescheduled.'
         runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubenodeunreachable
       expr: |
-        kube_node_spec_taint{job="kube-state-metrics",key="node.kubernetes.io/unreachable",effect="NoSchedule"} == 1
-      for: 2m
+        (kube_node_spec_taint{job="kube-state-metrics",key="node.kubernetes.io/unreachable",effect="NoSchedule"} unless ignoring(key,value) kube_node_spec_taint{job="kube-state-metrics",key="ToBeDeletedByClusterAutoscaler"}) == 1
       labels:
         severity: warning
     - alert: KubeletTooManyPods


### PR DESCRIPTION
Update endpoints on `prometheus-adapter` and `alertmanager` manifests to avoid `NXDOMAIN`s. 
I am fairly new to `jsonnet` so if there is any better way to do it feel free to correct me. 
I am sharing the following images to explain the reasoning behind this pull request. 
In the following image is shown the default setup of `alertmanager` that causes a noticeable amount of `NXDOMAIN` on dns lookups. 

![alertmanager_endpoint](https://user-images.githubusercontent.com/2853082/84375564-701e0780-abe8-11ea-9324-264edd1f8db4.png)

After we applied the proposed `alertmanager` changes on our setup these `NXDOMAIN`s were disappeared which improved our cluster performance by avoiding 3 `NXDOMAIN` per second. The same reasoning applies to the proposed change on `prometheus-adapter`.

![fixed_alertmanager_endpoints](https://user-images.githubusercontent.com/2853082/84374798-37c9f980-abe7-11ea-9cb0-445c883ec89e.png)


