### PR TITLE
Update prometheus-adapter endpoint

### DIFF
--- a/jsonnet/kube-prometheus/prometheus-adapter/prometheus-adapter.libsonnet
+++ b/jsonnet/kube-prometheus/prometheus-adapter/prometheus-adapter.libsonnet
@@ -15,7 +15,7 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
     prometheusAdapter+:: {
       name: 'prometheus-adapter',
       labels: { name: $._config.prometheusAdapter.name },
-      prometheusURL: 'http://prometheus-' + $._config.prometheus.name + '.' + $._config.namespace + '.svc:9090/',
+      prometheusURL: 'http://prometheus-' + $._config.prometheus.name + '.' + $._config.namespace + '.svc.cluster.local:9090/',
       config: {
         resourceRules: {
           cpu: {

--- a/jsonnetfile.lock.json
+++ b/jsonnetfile.lock.json
@@ -119,7 +119,7 @@
           "subdir": "documentation/prometheus-mixin"
         }
       },
-      "version": "8d3c2f6829d73be15a6684f9324917e72fbf1a31",
+      "version": "74207c04655e1fd93eea0e9a5d2f31b1cbc4d3d0",
       "sum": "lEzhZ8gllSfAO4kmXeTwl4W0anapIeFd5GCaCNuDe18=",
       "name": "prometheus"
     },

--- a/manifests/prometheus-adapter-deployment.yaml
+++ b/manifests/prometheus-adapter-deployment.yaml
@@ -23,7 +23,7 @@ spec:
         - --config=/etc/adapter/config.yaml
         - --logtostderr=true
         - --metrics-relist-interval=1m
-        - --prometheus-url=http://prometheus-k8s.monitoring.svc:9090/
+        - --prometheus-url=http://prometheus-k8s.monitoring.svc.cluster.local:9090/
         - --secure-port=6443
         image: quay.io/coreos/k8s-prometheus-adapter-amd64:v0.7.0
         name: prometheus-adapter


### PR DESCRIPTION
Change to `prometheus-adapter` endpoint to avoid 3 `NXDOMAIN` per second. 
More detailed reasoning on previous unmerged [PR](https://github.com/coreos/kube-prometheus/pull/570). 