### PR TITLE
Make node-exporter listening address configurable

### DIFF
--- a/jsonnet/kube-prometheus/node-exporter/node-exporter.libsonnet
+++ b/jsonnet/kube-prometheus/node-exporter/node-exporter.libsonnet
@@ -96,7 +96,7 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
       local nodeExporter =
         container.new('node-exporter', $._config.imageRepos.nodeExporter + ':' + $._config.versions.nodeExporter) +
         container.withArgs([
-          '--web.listen-address=' + std.join(':', [$._config.nodeExporter.listenAddress, $._config.nodeExporter.port]),
+          '--web.listen-address=' + std.join(':', [$._config.nodeExporter.listenAddress, std.toString($._config.nodeExporter.port)]),
           '--path.procfs=/host/proc',
           '--path.sysfs=/host/sys',
           '--path.rootfs=/host/root',

--- a/jsonnet/kube-prometheus/node-exporter/node-exporter.libsonnet
+++ b/jsonnet/kube-prometheus/node-exporter/node-exporter.libsonnet
@@ -15,6 +15,7 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
     },
 
     nodeExporter+:: {
+      listenAddress: '127.0.0.1',
       port: 9100,
       labels: {
         'app.kubernetes.io/name': 'node-exporter',
@@ -95,7 +96,7 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
       local nodeExporter =
         container.new('node-exporter', $._config.imageRepos.nodeExporter + ':' + $._config.versions.nodeExporter) +
         container.withArgs([
-          '--web.listen-address=127.0.0.1:' + $._config.nodeExporter.port,
+          '--web.listen-address=' + std.join(':', [$._config.nodeExporter.listenAddress, $._config.nodeExporter.port]),
           '--path.procfs=/host/proc',
           '--path.sysfs=/host/sys',
           '--path.rootfs=/host/root',


### PR DESCRIPTION
Hi

I have a few usecases were I would like to scrape the node exporter from outside of the Kubernetes cluster.

This PR makes listenAddress for node exporter configurable but continues to default to localhost to not break any current setups.

