### PR TITLE
modify kube-prometheus-static-etcd.libsonnet servicemonitorEtcd namespace

### DIFF
--- a/jsonnet/kube-prometheus/alerts/general.libsonnet
+++ b/jsonnet/kube-prometheus/alerts/general.libsonnet
@@ -15,6 +15,22 @@
               severity: 'warning',
             },
           },
+          {
+            alert: 'Watchdog',
+            annotations: {
+              message: |||
+                This is an alert meant to ensure that the entire alerting pipeline is functional.
+                This alert is always firing, therefore it should always be firing in Alertmanager
+                and always fire against a receiver. There are integrations with various notification
+                mechanisms that send a notification when this alert is not firing. For example the
+                "DeadMansSnitch" integration in PagerDuty.
+              |||,
+            },
+            expr: 'vector(1)',
+            labels: {
+              severity: 'none',
+            },
+          },
         ],
       },
     ],

--- a/jsonnet/kube-prometheus/alerts/general.libsonnet
+++ b/jsonnet/kube-prometheus/alerts/general.libsonnet
@@ -15,22 +15,6 @@
               severity: 'warning',
             },
           },
-          {
-            alert: 'Watchdog',
-            annotations: {
-              message: |||
-                This is an alert meant to ensure that the entire alerting pipeline is functional.
-                This alert is always firing, therefore it should always be firing in Alertmanager
-                and always fire against a receiver. There are integrations with various notification
-                mechanisms that send a notification when this alert is not firing. For example the
-                "DeadMansSnitch" integration in PagerDuty.
-              |||,
-            },
-            expr: 'vector(1)',
-            labels: {
-              severity: 'none',
-            },
-          },
         ],
       },
     ],

--- a/jsonnet/kube-prometheus/kube-prometheus-static-etcd.libsonnet
+++ b/jsonnet/kube-prometheus/kube-prometheus-static-etcd.libsonnet
@@ -50,7 +50,7 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
         kind: 'ServiceMonitor',
         metadata: {
           name: 'etcd',
-          namespace: 'kube-system',
+          namespace: $._config.namespace,
           labels: {
             'k8s-app': 'etcd',
           },


### PR DESCRIPTION
Prometheus does not watch  the kube-system namespce monitor object by default