### PR TITLE
enable etcd latency metrics in kube-apiserver

### DIFF
--- a/jsonnet/kube-prometheus/prometheus/prometheus.libsonnet
+++ b/jsonnet/kube-prometheus/prometheus/prometheus.libsonnet
@@ -407,7 +407,7 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
               metricRelabelings: (import 'kube-prometheus/dropping-deprecated-metrics-relabelings.libsonnet') + [
                 {
                   sourceLabels: ['__name__'],
-                  regex: 'etcd_(debugging|disk|request|server).*',
+                  regex: 'etcd_(debugging|disk|server).*',
                   action: 'drop',
                 },
                 {

--- a/manifests/prometheus-serviceMonitorApiserver.yaml
+++ b/manifests/prometheus-serviceMonitorApiserver.yaml
@@ -43,7 +43,7 @@ spec:
       sourceLabels:
       - __name__
     - action: drop
-      regex: etcd_(debugging|disk|request|server).*
+      regex: etcd_(debugging|disk|server).*
       sourceLabels:
       - __name__
     - action: drop


### PR DESCRIPTION
kube-apiserver has a histogram etcd_request_duration_seconds that measures latency between the kube-apiserver and etcd instance. This metrics is currently dropped by cluster-prometheus. Enable this metrics so we have visibility into etcd latency.

We ensured that this does not enable other unwanted metrcis

> count by(name) ({name=~"etcd_request.+"})

etcd_request_duration_seconds_bucket
etcd_request_duration_seconds_count
etcd_request_duration_seconds_sum