### PR TITLE
Remove instance:node_filesystem_usage:sum

### DIFF
--- a/jsonnet/kube-prometheus/rules/node-rules.libsonnet
+++ b/jsonnet/kube-prometheus/rules/node-rules.libsonnet
@@ -9,10 +9,6 @@
             record: 'instance:node_cpu:rate:sum',
           },
           {
-            expr: 'sum((node_filesystem_size_bytes{mountpoint="/"} - node_filesystem_free_bytes{mountpoint="/"})) BY (instance)',
-            record: 'instance:node_filesystem_usage:sum',
-          },
-          {
             expr: 'sum(rate(node_network_receive_bytes_total[3m])) BY (instance)',
             record: 'instance:node_network_receive_bytes:rate:sum',
           },

--- a/manifests/prometheus-rules.yaml
+++ b/manifests/prometheus-rules.yaml
@@ -711,9 +711,6 @@ spec:
     - expr: sum(rate(node_cpu_seconds_total{mode!="idle",mode!="iowait"}[3m])) BY
         (instance)
       record: instance:node_cpu:rate:sum
-    - expr: sum((node_filesystem_size_bytes{mountpoint="/"} - node_filesystem_free_bytes{mountpoint="/"}))
-        BY (instance)
-      record: instance:node_filesystem_usage:sum
     - expr: sum(rate(node_network_receive_bytes_total[3m])) BY (instance)
       record: instance:node_network_receive_bytes:rate:sum
     - expr: sum(rate(node_network_transmit_bytes_total[3m])) BY (instance)


### PR DESCRIPTION
Removing `instance:node_filesystem_usage:sum` as it isn't used in any dashboard or alert shipped with kube-prometheus.

Additionally, in most cases, the user is more concerned about `sum by (instance) (node_filesystem_avail_bytes)` and not data presented by this recording rule - [more on the topic](https://www.robustperception.io/filesystem-metrics-from-the-node-exporter).