### PR TITLE
secure metrics port for scheduler and controller-manager

### DIFF
--- a/jsonnet/kube-prometheus/kube-prometheus-bootkube.libsonnet
+++ b/jsonnet/kube-prometheus/kube-prometheus-bootkube.libsonnet
@@ -5,12 +5,12 @@ local servicePort = k.core.v1.service.mixin.spec.portsType;
 {
   prometheus+:: {
     kubeControllerManagerPrometheusDiscoveryService:
-      service.new('kube-controller-manager-prometheus-discovery', { 'k8s-app': 'kube-controller-manager' }, servicePort.newNamed('http-metrics', 10257, 10257)) +
+      service.new('kube-controller-manager-prometheus-discovery', { 'k8s-app': 'kube-controller-manager' }, servicePort.newNamed('https-metrics', 10257, 10257)) +
       service.mixin.metadata.withNamespace('kube-system') +
       service.mixin.metadata.withLabels({ 'k8s-app': 'kube-controller-manager' }) +
       service.mixin.spec.withClusterIp('None'),
     kubeSchedulerPrometheusDiscoveryService:
-      service.new('kube-scheduler-prometheus-discovery', { 'k8s-app': 'kube-scheduler' }, servicePort.newNamed('http-metrics', 10259, 10259)) +
+      service.new('kube-scheduler-prometheus-discovery', { 'k8s-app': 'kube-scheduler' }, servicePort.newNamed('https-metrics', 10259, 10259)) +
       service.mixin.metadata.withNamespace('kube-system') +
       service.mixin.metadata.withLabels({ 'k8s-app': 'kube-scheduler' }) +
       service.mixin.spec.withClusterIp('None'),

--- a/jsonnet/kube-prometheus/kube-prometheus-bootkube.libsonnet
+++ b/jsonnet/kube-prometheus/kube-prometheus-bootkube.libsonnet
@@ -5,12 +5,12 @@ local servicePort = k.core.v1.service.mixin.spec.portsType;
 {
   prometheus+:: {
     kubeControllerManagerPrometheusDiscoveryService:
-      service.new('kube-controller-manager-prometheus-discovery', { 'k8s-app': 'kube-controller-manager' }, servicePort.newNamed('http-metrics', 10252, 10252)) +
+      service.new('kube-controller-manager-prometheus-discovery', { 'k8s-app': 'kube-controller-manager' }, servicePort.newNamed('http-metrics', 10257, 10257)) +
       service.mixin.metadata.withNamespace('kube-system') +
       service.mixin.metadata.withLabels({ 'k8s-app': 'kube-controller-manager' }) +
       service.mixin.spec.withClusterIp('None'),
     kubeSchedulerPrometheusDiscoveryService:
-      service.new('kube-scheduler-prometheus-discovery', { 'k8s-app': 'kube-scheduler' }, servicePort.newNamed('http-metrics', 10251, 10251)) +
+      service.new('kube-scheduler-prometheus-discovery', { 'k8s-app': 'kube-scheduler' }, servicePort.newNamed('http-metrics', 10259, 10259)) +
       service.mixin.metadata.withNamespace('kube-system') +
       service.mixin.metadata.withLabels({ 'k8s-app': 'kube-scheduler' }) +
       service.mixin.spec.withClusterIp('None'),

--- a/jsonnet/kube-prometheus/kube-prometheus-kops.libsonnet
+++ b/jsonnet/kube-prometheus/kube-prometheus-kops.libsonnet
@@ -5,12 +5,12 @@ local servicePort = k.core.v1.service.mixin.spec.portsType;
 {
   prometheus+:: {
     kubeControllerManagerPrometheusDiscoveryService:
-      service.new('kube-controller-manager-prometheus-discovery', { 'k8s-app': 'kube-controller-manager' }, servicePort.newNamed('http-metrics', 10257, 10257)) +
+      service.new('kube-controller-manager-prometheus-discovery', { 'k8s-app': 'kube-controller-manager' }, servicePort.newNamed('https-metrics', 10257, 10257)) +
       service.mixin.metadata.withNamespace('kube-system') +
       service.mixin.metadata.withLabels({ 'k8s-app': 'kube-controller-manager' }) +
       service.mixin.spec.withClusterIp('None'),
     kubeSchedulerPrometheusDiscoveryService:
-      service.new('kube-scheduler-prometheus-discovery', { 'k8s-app': 'kube-scheduler' }, servicePort.newNamed('http-metrics', 10259, 10259)) +
+      service.new('kube-scheduler-prometheus-discovery', { 'k8s-app': 'kube-scheduler' }, servicePort.newNamed('https-metrics', 10259, 10259)) +
       service.mixin.metadata.withNamespace('kube-system') +
       service.mixin.metadata.withLabels({ 'k8s-app': 'kube-scheduler' }) +
       service.mixin.spec.withClusterIp('None'),

--- a/jsonnet/kube-prometheus/kube-prometheus-kops.libsonnet
+++ b/jsonnet/kube-prometheus/kube-prometheus-kops.libsonnet
@@ -5,12 +5,12 @@ local servicePort = k.core.v1.service.mixin.spec.portsType;
 {
   prometheus+:: {
     kubeControllerManagerPrometheusDiscoveryService:
-      service.new('kube-controller-manager-prometheus-discovery', { 'k8s-app': 'kube-controller-manager' }, servicePort.newNamed('http-metrics', 10252, 10252)) +
+      service.new('kube-controller-manager-prometheus-discovery', { 'k8s-app': 'kube-controller-manager' }, servicePort.newNamed('http-metrics', 10257, 10257)) +
       service.mixin.metadata.withNamespace('kube-system') +
       service.mixin.metadata.withLabels({ 'k8s-app': 'kube-controller-manager' }) +
       service.mixin.spec.withClusterIp('None'),
     kubeSchedulerPrometheusDiscoveryService:
-      service.new('kube-scheduler-prometheus-discovery', { 'k8s-app': 'kube-scheduler' }, servicePort.newNamed('http-metrics', 10251, 10251)) +
+      service.new('kube-scheduler-prometheus-discovery', { 'k8s-app': 'kube-scheduler' }, servicePort.newNamed('http-metrics', 10259, 10259)) +
       service.mixin.metadata.withNamespace('kube-system') +
       service.mixin.metadata.withLabels({ 'k8s-app': 'kube-scheduler' }) +
       service.mixin.spec.withClusterIp('None'),

--- a/jsonnet/kube-prometheus/kube-prometheus-kube-aws.libsonnet
+++ b/jsonnet/kube-prometheus/kube-prometheus-kube-aws.libsonnet
@@ -5,12 +5,12 @@ local servicePort = k.core.v1.service.mixin.spec.portsType;
 {
   prometheus+: {
     kubeControllerManagerPrometheusDiscoveryService:
-      service.new('kube-controller-manager-prometheus-discovery', { 'k8s-app': 'kube-controller-manager' }, servicePort.newNamed('http-metrics', 10257, 10257)) +
+      service.new('kube-controller-manager-prometheus-discovery', { 'k8s-app': 'kube-controller-manager' }, servicePort.newNamed('https-metrics', 10257, 10257)) +
       service.mixin.metadata.withNamespace('kube-system') +
       service.mixin.metadata.withLabels({ 'k8s-app': 'kube-controller-manager' }) +
       service.mixin.spec.withClusterIp('None'),
     kubeSchedulerPrometheusDiscoveryService:
-      service.new('kube-scheduler-prometheus-discovery', { 'k8s-app': 'kube-scheduler' }, servicePort.newNamed('http-metrics', 10259, 10259)) +
+      service.new('kube-scheduler-prometheus-discovery', { 'k8s-app': 'kube-scheduler' }, servicePort.newNamed('https-metrics', 10259, 10259)) +
       service.mixin.metadata.withNamespace('kube-system') +
       service.mixin.metadata.withLabels({ 'k8s-app': 'kube-scheduler' }) +
       service.mixin.spec.withClusterIp('None'),

--- a/jsonnet/kube-prometheus/kube-prometheus-kube-aws.libsonnet
+++ b/jsonnet/kube-prometheus/kube-prometheus-kube-aws.libsonnet
@@ -5,12 +5,12 @@ local servicePort = k.core.v1.service.mixin.spec.portsType;
 {
   prometheus+: {
     kubeControllerManagerPrometheusDiscoveryService:
-      service.new('kube-controller-manager-prometheus-discovery', { 'k8s-app': 'kube-controller-manager' }, servicePort.newNamed('http-metrics', 10252, 10252)) +
+      service.new('kube-controller-manager-prometheus-discovery', { 'k8s-app': 'kube-controller-manager' }, servicePort.newNamed('http-metrics', 10257, 10257)) +
       service.mixin.metadata.withNamespace('kube-system') +
       service.mixin.metadata.withLabels({ 'k8s-app': 'kube-controller-manager' }) +
       service.mixin.spec.withClusterIp('None'),
     kubeSchedulerPrometheusDiscoveryService:
-      service.new('kube-scheduler-prometheus-discovery', { 'k8s-app': 'kube-scheduler' }, servicePort.newNamed('http-metrics', 10251, 10251)) +
+      service.new('kube-scheduler-prometheus-discovery', { 'k8s-app': 'kube-scheduler' }, servicePort.newNamed('http-metrics', 10259, 10259)) +
       service.mixin.metadata.withNamespace('kube-system') +
       service.mixin.metadata.withLabels({ 'k8s-app': 'kube-scheduler' }) +
       service.mixin.spec.withClusterIp('None'),

--- a/jsonnet/kube-prometheus/kube-prometheus-kubeadm.libsonnet
+++ b/jsonnet/kube-prometheus/kube-prometheus-kubeadm.libsonnet
@@ -5,12 +5,12 @@ local servicePort = k.core.v1.service.mixin.spec.portsType;
 {
   prometheus+: {
     kubeControllerManagerPrometheusDiscoveryService:
-      service.new('kube-controller-manager-prometheus-discovery', { component: 'kube-controller-manager' }, servicePort.newNamed('http-metrics', 10257, 10257)) +
+      service.new('kube-controller-manager-prometheus-discovery', { component: 'kube-controller-manager' }, servicePort.newNamed('https-metrics', 10257, 10257)) +
       service.mixin.metadata.withNamespace('kube-system') +
       service.mixin.metadata.withLabels({ 'k8s-app': 'kube-controller-manager' }) +
       service.mixin.spec.withClusterIp('None'),
     kubeSchedulerPrometheusDiscoveryService:
-      service.new('kube-scheduler-prometheus-discovery', { component: 'kube-scheduler' }, servicePort.newNamed('http-metrics', 10259, 10259)) +
+      service.new('kube-scheduler-prometheus-discovery', { component: 'kube-scheduler' }, servicePort.newNamed('https-metrics', 10259, 10259)) +
       service.mixin.metadata.withNamespace('kube-system') +
       service.mixin.metadata.withLabels({ 'k8s-app': 'kube-scheduler' }) +
       service.mixin.spec.withClusterIp('None'),

--- a/jsonnet/kube-prometheus/kube-prometheus-kubeadm.libsonnet
+++ b/jsonnet/kube-prometheus/kube-prometheus-kubeadm.libsonnet
@@ -5,12 +5,12 @@ local servicePort = k.core.v1.service.mixin.spec.portsType;
 {
   prometheus+: {
     kubeControllerManagerPrometheusDiscoveryService:
-      service.new('kube-controller-manager-prometheus-discovery', { component: 'kube-controller-manager' }, servicePort.newNamed('http-metrics', 10252, 10252)) +
+      service.new('kube-controller-manager-prometheus-discovery', { component: 'kube-controller-manager' }, servicePort.newNamed('http-metrics', 10257, 10257)) +
       service.mixin.metadata.withNamespace('kube-system') +
       service.mixin.metadata.withLabels({ 'k8s-app': 'kube-controller-manager' }) +
       service.mixin.spec.withClusterIp('None'),
     kubeSchedulerPrometheusDiscoveryService:
-      service.new('kube-scheduler-prometheus-discovery', { component: 'kube-scheduler' }, servicePort.newNamed('http-metrics', 10251, 10251)) +
+      service.new('kube-scheduler-prometheus-discovery', { component: 'kube-scheduler' }, servicePort.newNamed('http-metrics', 10259, 10259)) +
       service.mixin.metadata.withNamespace('kube-system') +
       service.mixin.metadata.withLabels({ 'k8s-app': 'kube-scheduler' }) +
       service.mixin.spec.withClusterIp('None'),

--- a/jsonnet/kube-prometheus/kube-prometheus-kubespray.libsonnet
+++ b/jsonnet/kube-prometheus/kube-prometheus-kubespray.libsonnet
@@ -6,12 +6,12 @@ local servicePort = k.core.v1.service.mixin.spec.portsType;
 
   prometheus+: {
     kubeControllerManagerPrometheusDiscoveryService:
-      service.new('kube-controller-manager-prometheus-discovery', { 'component': 'kube-controller-manager' }, servicePort.newNamed('http-metrics', 10257, 10257)) +
+      service.new('kube-controller-manager-prometheus-discovery', { 'component': 'kube-controller-manager' }, servicePort.newNamed('https-metrics', 10257, 10257)) +
       service.mixin.metadata.withNamespace('kube-system') +
       service.mixin.metadata.withLabels({ 'k8s-app': 'kube-controller-manager' }) +
       service.mixin.spec.withClusterIp('None'),
     kubeSchedulerPrometheusDiscoveryService:
-      service.new('kube-scheduler-prometheus-discovery', { 'component': 'kube-scheduler' }, servicePort.newNamed('http-metrics', 10259, 10259)) +
+      service.new('kube-scheduler-prometheus-discovery', { 'component': 'kube-scheduler' }, servicePort.newNamed('https-metrics', 10259, 10259)) +
       service.mixin.metadata.withNamespace('kube-system') +
       service.mixin.metadata.withLabels({ 'k8s-app': 'kube-scheduler' }) +
       service.mixin.spec.withClusterIp('None'),

--- a/jsonnet/kube-prometheus/kube-prometheus-kubespray.libsonnet
+++ b/jsonnet/kube-prometheus/kube-prometheus-kubespray.libsonnet
@@ -6,12 +6,12 @@ local servicePort = k.core.v1.service.mixin.spec.portsType;
 
   prometheus+: {
     kubeControllerManagerPrometheusDiscoveryService:
-      service.new('kube-controller-manager-prometheus-discovery', { 'component': 'kube-controller-manager' }, servicePort.newNamed('http-metrics', 10252, 10252)) +
+      service.new('kube-controller-manager-prometheus-discovery', { 'component': 'kube-controller-manager' }, servicePort.newNamed('http-metrics', 10257, 10257)) +
       service.mixin.metadata.withNamespace('kube-system') +
       service.mixin.metadata.withLabels({ 'k8s-app': 'kube-controller-manager' }) +
       service.mixin.spec.withClusterIp('None'),
     kubeSchedulerPrometheusDiscoveryService:
-      service.new('kube-scheduler-prometheus-discovery', { 'component': 'kube-scheduler' }, servicePort.newNamed('http-metrics', 10251, 10251)) +
+      service.new('kube-scheduler-prometheus-discovery', { 'component': 'kube-scheduler' }, servicePort.newNamed('http-metrics', 10259, 10259)) +
       service.mixin.metadata.withNamespace('kube-system') +
       service.mixin.metadata.withLabels({ 'k8s-app': 'kube-scheduler' }) +
       service.mixin.spec.withClusterIp('None'),

--- a/jsonnet/kube-prometheus/prometheus/prometheus.libsonnet
+++ b/jsonnet/kube-prometheus/prometheus/prometheus.libsonnet
@@ -246,7 +246,7 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
           jobLabel: 'k8s-app',
           endpoints: [
             {
-              port: 'http-metrics',
+              port: 'https-metrics',
               interval: '30s',
               scheme: "https",
               bearerTokenFile: "/var/run/secrets/kubernetes.io/serviceaccount/token",
@@ -352,7 +352,7 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
           jobLabel: 'k8s-app',
           endpoints: [
             {
-              port: 'http-metrics',
+              port: 'https-metrics',
               interval: '30s',
               scheme: "https",
               bearerTokenFile: "/var/run/secrets/kubernetes.io/serviceaccount/token",

--- a/jsonnet/kube-prometheus/prometheus/prometheus.libsonnet
+++ b/jsonnet/kube-prometheus/prometheus/prometheus.libsonnet
@@ -248,6 +248,11 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
             {
               port: 'http-metrics',
               interval: '30s',
+              scheme: "https",
+              bearerTokenFile: "/var/run/secrets/kubernetes.io/serviceaccount/token",
+              tlsConfig: {
+                insecureSkipVerify: true
+              }
             },
           ],
           selector: {
@@ -349,6 +354,11 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
             {
               port: 'http-metrics',
               interval: '30s',
+              scheme: "https",
+              bearerTokenFile: "/var/run/secrets/kubernetes.io/serviceaccount/token",
+              tlsConfig: {
+                insecureSkipVerify: true
+              },
               metricRelabelings: (import 'kube-prometheus/dropping-deprecated-metrics-relabelings.libsonnet') + [
                 {
                   sourceLabels: ['__name__'],

--- a/manifests/prometheus-serviceMonitorKubeControllerManager.yaml
+++ b/manifests/prometheus-serviceMonitorKubeControllerManager.yaml
@@ -7,7 +7,8 @@ metadata:
   namespace: monitoring
 spec:
   endpoints:
-  - interval: 30s
+  - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    interval: 30s
     metricRelabelings:
     - action: drop
       regex: kubelet_(pod_worker_latency_microseconds|pod_start_latency_microseconds|cgroup_manager_latency_microseconds|pod_worker_start_latency_microseconds|pleg_relist_latency_microseconds|pleg_relist_interval_microseconds|runtime_operations|runtime_operations_latency_microseconds|runtime_operations_errors|eviction_stats_age_microseconds|device_plugin_registration_count|device_plugin_alloc_latency_microseconds|network_plugin_operations_latency_microseconds)
@@ -45,7 +46,10 @@ spec:
       regex: etcd_(debugging|disk|request|server).*
       sourceLabels:
       - __name__
-    port: http-metrics
+    port: https-metrics
+    scheme: https
+    tlsConfig:
+      insecureSkipVerify: true
   jobLabel: k8s-app
   namespaceSelector:
     matchNames:

--- a/manifests/prometheus-serviceMonitorKubeScheduler.yaml
+++ b/manifests/prometheus-serviceMonitorKubeScheduler.yaml
@@ -7,8 +7,12 @@ metadata:
   namespace: monitoring
 spec:
   endpoints:
-  - interval: 30s
-    port: http-metrics
+  - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    interval: 30s
+    port: https-metrics
+    scheme: https
+    tlsConfig:
+      insecureSkipVerify: true
   jobLabel: k8s-app
   namespaceSelector:
     matchNames:


### PR DESCRIPTION
fixes https://github.com/coreos/kube-prometheus/issues/443
tested with 1.17.9 kubeadm cluster, after kubeadm upgrade disabled the insecure metrics port for scheduler+controller.
also changed the ports for other cluster-types, but i can't really say if the secure port is provided on those platforms.